### PR TITLE
docs(unity-cli-bridge): document legacy shim removal criteria

### DIFF
--- a/UnityCliBridge/Packages/unity-cli-bridge/Editor/Settings/LegacyUnityMcpServerProjectSettings.cs
+++ b/UnityCliBridge/Packages/unity-cli-bridge/Editor/Settings/LegacyUnityMcpServerProjectSettings.cs
@@ -2,7 +2,15 @@ using UnityEditor;
 
 namespace UnityMCPServer.Settings
 {
-    // Compatibility wrapper so legacy serialized ProjectSettings asset can still resolve.
+    /// <summary>
+    /// Compatibility shim that keeps legacy <c>UnityMCPServer.Settings</c> settings deserialization working.
+    /// This type maps legacy <c>ProjectSettings/UnityMcpServerSettings.asset</c> data to
+    /// <see cref="UnityCliBridge.Settings.UnityCliBridgeProjectSettings"/> for projects migrated from
+    /// the old unity-mcp-server package.
+    /// Remove only after all supported projects no longer contain
+    /// <c>ProjectSettings/UnityMcpServerSettings.asset</c> and have fully migrated to
+    /// <c>ProjectSettings/UnityCliBridgeSettings.asset</c>.
+    /// </summary>
     [FilePath("ProjectSettings/UnityMcpServerSettings.asset", FilePathAttribute.Location.ProjectFolder)]
     internal class UnityMcpServerProjectSettings : UnityCliBridge.Settings.UnityCliBridgeProjectSettings
     {

--- a/UnityCliBridge/Packages/unity-cli-bridge/Runtime/IMGUI/LegacyMcpImguiControlRegistry.cs
+++ b/UnityCliBridge/Packages/unity-cli-bridge/Runtime/IMGUI/LegacyMcpImguiControlRegistry.cs
@@ -6,7 +6,15 @@ using UnityEngine;
 
 namespace UnityMCPServer.Runtime.IMGUI
 {
-    // Compatibility bridge for legacy test scripts that still reference UnityMCPServer.* namespaces.
+    /// <summary>
+    /// Compatibility bridge for code that still references
+    /// <c>UnityMCPServer.Runtime.IMGUI.McpImguiControlRegistry</c>.
+    /// The implementation delegates to
+    /// <see cref="UnityCliBridge.Runtime.IMGUI.McpImguiControlRegistry"/> so migrated projects can keep
+    /// legacy namespace references during transition.
+    /// Remove only after all supported projects (including TestProject and downstream user projects)
+    /// no longer reference <c>UnityMCPServer.*</c> IMGUI registry types.
+    /// </summary>
     public static class McpImguiControlRegistry
     {
         public struct ControlSnapshot


### PR DESCRIPTION
## Summary

- Added XML documentation comments to two legacy compatibility shim classes so maintainers understand why these aliases still exist.
- Documented explicit removal criteria in code comments so the shims are not removed before migration compatibility is complete.

## Changes

- `UnityCliBridge/Packages/unity-cli-bridge/Editor/Settings/LegacyUnityMcpServerProjectSettings.cs`: Replaced inline comment with a `/// <summary>` block describing deserialization compatibility for `ProjectSettings/UnityMcpServerSettings.asset` and when removal is safe.
- `UnityCliBridge/Packages/unity-cli-bridge/Runtime/IMGUI/LegacyMcpImguiControlRegistry.cs`: Replaced inline comment with a `/// <summary>` block describing namespace-compatibility delegation and when removal is safe.

## Testing

- [x] `cargo test --all-targets` — all tests passed locally (36 passed, 0 failed).
- [ ] `dotnet test lsp/Server.Tests.csproj` — not run because `dotnet` is not installed in this environment.

## Related Issues / Links

- #21

## Checklist

- [x] Tests added/updated — N/A: comment-only change with no behavior change.
- [ ] Lint/format passed (`cargo clippy`, `cargo fmt`, `svelte-check`) — not run in this step.
- [x] Documentation updated (if user-facing change) — added XML documentation comments for legacy compatibility shims.
- [x] Migration/backfill plan included (if schema/data change) — N/A: no schema or data changes.
- [x] CHANGELOG impact considered (breaking change flagged in commit) — N/A: no breaking change.
