### PR TITLE
fix(lsp): preserve safe defaults and actionable errors

### DIFF
--- a/src/local_tools.rs
+++ b/src/local_tools.rs
@@ -67,6 +67,13 @@ pub fn maybe_execute_local_tool(tool_name: &str, params: &Value) -> Option<Resul
         "update_index" => Some(local_update_index(params)),
         "find_symbol" => Some(local_find_symbol(params)),
         "find_refs" => Some(local_find_refs(params)),
+        "rename_symbol" => Some(local_lsp_write("rename_symbol", params)),
+        "replace_symbol_body" => Some(local_lsp_write("replace_symbol_body", params)),
+        "insert_before_symbol" => Some(local_lsp_write("insert_before_symbol", params)),
+        "insert_after_symbol" => Some(local_lsp_write("insert_after_symbol", params)),
+        "remove_symbol" => Some(local_lsp_write("remove_symbol", params)),
+        "validate_text_edits" => Some(local_lsp_write("validate_text_edits", params)),
+        "create_class" => Some(local_create_class(params)),
         _ => None,
     }
 }
@@ -649,6 +656,104 @@ fn local_find_refs(params: &Value) -> Result<Value> {
     }
 
     Ok(response)
+}
+
+fn local_lsp_write(tool_name: &str, params: &Value) -> Result<Value> {
+    let root = project_root()?;
+    if let Some(result) = crate::lsp::maybe_execute(tool_name, params, &root) {
+        return result;
+    }
+
+    let mode = env::var("UNITY_CLI_LSP_MODE")
+        .ok()
+        .unwrap_or_else(|| "off".to_string())
+        .to_ascii_lowercase();
+    if mode == "auto" || mode == "required" {
+        return crate::lsp::execute_direct(tool_name, params, &root);
+    }
+
+    Err(anyhow!(
+        "{tool_name} requires LSP; set UNITY_CLI_LSP_MODE=auto or required"
+    ))
+}
+
+fn requires_unityengine_using(inherits: Option<&str>) -> bool {
+    matches!(inherits.map(str::trim), Some("MonoBehaviour"))
+}
+
+fn local_create_class(params: &Value) -> Result<Value> {
+    let name = params
+        .get("name")
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow!("create_class requires `name`"))?;
+    let namespace = params.get("namespace").and_then(Value::as_str);
+    let inherits = params.get("inherits").and_then(Value::as_str);
+    let folder = params
+        .get("folder")
+        .and_then(Value::as_str)
+        .unwrap_or("Assets/Scripts");
+    let path_override = params.get("path").and_then(Value::as_str);
+
+    if !name
+        .chars()
+        .next()
+        .map(|c| c.is_ascii_alphabetic() || c == '_')
+        .unwrap_or(false)
+    {
+        return Err(anyhow!("Invalid class name: {name}"));
+    }
+    if !name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_') {
+        return Err(anyhow!("Invalid class name: {name}"));
+    }
+
+    let root = project_root()?;
+
+    let rel_path = if let Some(p) = path_override {
+        let normalized = normalize_rel_path(p)
+            .ok_or_else(|| anyhow!("path must start with Assets/ or Packages/"))?;
+        normalized
+    } else {
+        let normalized_folder = normalize_rel_path(folder)
+            .ok_or_else(|| anyhow!("folder must start with Assets/ or Packages/"))?;
+        format!("{normalized_folder}/{name}.cs")
+    };
+
+    let abs_path = root.join(&rel_path);
+    if abs_path.exists() {
+        return Err(anyhow!("File already exists: {rel_path}"));
+    }
+
+    let mut body = String::new();
+    if requires_unityengine_using(inherits) {
+        body.push_str("using UnityEngine;\n\n");
+    }
+
+    if let Some(ns) = namespace {
+        body.push_str(&format!("namespace {ns}\n{{\n"));
+    }
+
+    let indent = if namespace.is_some() { "    " } else { "" };
+    let base = inherits.map(|b| format!(" : {b}")).unwrap_or_default();
+
+    body.push_str(&format!(
+        "{indent}public class {name}{base}\n{indent}{{\n{indent}}}\n"
+    ));
+
+    if namespace.is_some() {
+        body.push_str("}\n");
+    }
+
+    if let Some(parent) = abs_path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("Failed to create directory: {}", parent.display()))?;
+    }
+    fs::write(&abs_path, &body).with_context(|| format!("Failed to write file: {rel_path}"))?;
+
+    Ok(json!({
+        "success": true,
+        "path": rel_path,
+        "content": body
+    }))
 }
 
 fn project_root() -> Result<PathBuf> {
@@ -1414,5 +1519,132 @@ mod tests {
         );
 
         std::env::remove_var("UNITY_PROJECT_ROOT");
+    }
+
+    #[test]
+    fn create_class_generates_simple_class() {
+        let _guard = env_lock().lock().expect("lock should succeed");
+        let tmp = tempfile::tempdir().expect("temp dir should be created");
+        std::env::set_var("UNITY_PROJECT_ROOT", tmp.path());
+
+        let value = maybe_execute_local_tool(
+            "create_class",
+            &json!({"name":"EnemyAI","folder":"Assets/Scripts/AI"}),
+        )
+        .expect("tool should be handled")
+        .expect("create_class should succeed");
+
+        assert_eq!(value["success"], true);
+        assert_eq!(value["path"], "Assets/Scripts/AI/EnemyAI.cs");
+        let content = value["content"].as_str().expect("content should be string");
+        assert!(!content.contains("using UnityEngine;"));
+        assert!(content.contains("public class EnemyAI"));
+
+        let file_content = std::fs::read_to_string(tmp.path().join("Assets/Scripts/AI/EnemyAI.cs"))
+            .expect("file should exist");
+        assert_eq!(file_content, content);
+
+        std::env::remove_var("UNITY_PROJECT_ROOT");
+    }
+
+    #[test]
+    fn create_class_with_namespace_and_inherits() {
+        let _guard = env_lock().lock().expect("lock should succeed");
+        let tmp = tempfile::tempdir().expect("temp dir should be created");
+        std::env::set_var("UNITY_PROJECT_ROOT", tmp.path());
+
+        let value = maybe_execute_local_tool(
+            "create_class",
+            &json!({
+                "name": "Player",
+                "namespace": "Game.Characters",
+                "inherits": "MonoBehaviour",
+                "folder": "Assets/Scripts"
+            }),
+        )
+        .expect("tool should be handled")
+        .expect("create_class should succeed");
+
+        assert_eq!(value["success"], true);
+        let content = value["content"].as_str().expect("content should be string");
+        assert!(content.contains("namespace Game.Characters"));
+        assert!(content.contains("using UnityEngine;"));
+        assert!(content.contains("public class Player : MonoBehaviour"));
+
+        std::env::remove_var("UNITY_PROJECT_ROOT");
+    }
+
+    #[test]
+    fn create_class_rejects_existing_file() {
+        let _guard = env_lock().lock().expect("lock should succeed");
+        let tmp = tempfile::tempdir().expect("temp dir should be created");
+        write_file(
+            &tmp.path().join("Assets/Scripts/Existing.cs"),
+            "public class Existing {}\n",
+        );
+        std::env::set_var("UNITY_PROJECT_ROOT", tmp.path());
+
+        let result = maybe_execute_local_tool(
+            "create_class",
+            &json!({"name":"Existing","folder":"Assets/Scripts"}),
+        )
+        .expect("tool should be handled");
+
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("File already exists"));
+
+        std::env::remove_var("UNITY_PROJECT_ROOT");
+    }
+
+    #[test]
+    fn create_class_rejects_invalid_name() {
+        let _guard = env_lock().lock().expect("lock should succeed");
+        let tmp = tempfile::tempdir().expect("temp dir should be created");
+        std::env::set_var("UNITY_PROJECT_ROOT", tmp.path());
+
+        let result = maybe_execute_local_tool(
+            "create_class",
+            &json!({"name":"123Invalid","folder":"Assets/Scripts"}),
+        )
+        .expect("tool should be handled");
+
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Invalid class name"));
+
+        std::env::remove_var("UNITY_PROJECT_ROOT");
+    }
+
+    #[test]
+    fn lsp_write_tools_require_lsp_mode() {
+        let _guard = env_lock().lock().expect("lock should succeed");
+        let tmp = tempfile::tempdir().expect("temp dir should be created");
+        std::env::set_var("UNITY_PROJECT_ROOT", tmp.path());
+        std::env::set_var("UNITY_CLI_LSP_MODE", "off");
+
+        for tool in &[
+            "rename_symbol",
+            "replace_symbol_body",
+            "insert_before_symbol",
+            "insert_after_symbol",
+            "remove_symbol",
+            "validate_text_edits",
+        ] {
+            let result =
+                maybe_execute_local_tool(tool, &json!({})).expect("tool should be handled");
+            assert!(result.is_err(), "{tool} should fail when LSP is off");
+            assert!(
+                result.unwrap_err().to_string().contains("requires LSP"),
+                "{tool} should mention LSP requirement"
+            );
+        }
+
+        std::env::remove_var("UNITY_PROJECT_ROOT");
+        std::env::remove_var("UNITY_CLI_LSP_MODE");
     }
 }

--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -47,7 +47,16 @@ pub fn maybe_execute(
 ) -> Option<Result<Value>> {
     if !matches!(
         tool_name,
-        "get_symbols" | "find_symbol" | "find_refs" | "build_index"
+        "get_symbols"
+            | "find_symbol"
+            | "find_refs"
+            | "build_index"
+            | "rename_symbol"
+            | "replace_symbol_body"
+            | "insert_before_symbol"
+            | "insert_after_symbol"
+            | "remove_symbol"
+            | "validate_text_edits"
     ) {
         return None;
     }
@@ -131,6 +140,20 @@ fn execute_once(tool_name: &str, params: &Value, project_root: &Path) -> Result<
         "find_symbol" => handle_find_symbol(&mut cached.session, &canonical_root, params),
         "find_refs" => handle_find_refs(&mut cached.session, &canonical_root, params),
         "build_index" => handle_build_index(&mut cached.session, &canonical_root, params),
+        "rename_symbol" => handle_rename_symbol(&mut cached.session, &canonical_root, params),
+        "replace_symbol_body" => {
+            handle_replace_symbol_body(&mut cached.session, &canonical_root, params)
+        }
+        "insert_before_symbol" => {
+            handle_insert_symbol(&mut cached.session, &canonical_root, params, false)
+        }
+        "insert_after_symbol" => {
+            handle_insert_symbol(&mut cached.session, &canonical_root, params, true)
+        }
+        "remove_symbol" => handle_remove_symbol(&mut cached.session, &canonical_root, params),
+        "validate_text_edits" => {
+            handle_validate_text_edits(&mut cached.session, &canonical_root, params)
+        }
         _ => Err(anyhow!("Unsupported LSP tool: {tool_name}")),
     }
 }
@@ -472,6 +495,232 @@ fn handle_build_index(
 
     response["raw"] = result;
     Ok(response)
+}
+
+fn require_relative_path(params: &Value, tool_name: &str) -> Result<String> {
+    let path = params
+        .get("relative")
+        .or_else(|| params.get("path"))
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow!("{tool_name} requires `relative`"))?;
+    normalize_rel_path(path).ok_or_else(|| anyhow!("path must start with Assets/ or Packages/"))
+}
+
+fn require_name_path(params: &Value, tool_name: &str) -> Result<String> {
+    params
+        .get("namePath")
+        .and_then(Value::as_str)
+        .map(String::from)
+        .ok_or_else(|| anyhow!("{tool_name} requires `namePath`"))
+}
+
+fn get_apply(params: &Value) -> bool {
+    params
+        .get("apply")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+}
+
+fn handle_rename_symbol(
+    session: &mut LspSession,
+    project_root: &Path,
+    params: &Value,
+) -> Result<Value> {
+    let rel = require_relative_path(params, "rename_symbol")?;
+    let name_path = require_name_path(params, "rename_symbol")?;
+    let new_name = params
+        .get("newName")
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow!("rename_symbol requires `newName`"))?;
+    let apply = get_apply(params);
+
+    let abs = project_root.join(&rel);
+    if !abs.exists() {
+        return Err(anyhow!("File not found: {rel}"));
+    }
+
+    let result = session.request(
+        "unitycli/renameByNamePath",
+        json!({
+            "relative": rel,
+            "namePath": name_path,
+            "newName": new_name,
+            "apply": apply
+        }),
+    )?;
+
+    Ok(wrap_lsp_write_result(result))
+}
+
+fn handle_replace_symbol_body(
+    session: &mut LspSession,
+    project_root: &Path,
+    params: &Value,
+) -> Result<Value> {
+    let rel = require_relative_path(params, "replace_symbol_body")?;
+    let name_path = require_name_path(params, "replace_symbol_body")?;
+    let body = params
+        .get("body")
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow!("replace_symbol_body requires `body`"))?;
+    let apply = get_apply(params);
+
+    let abs = project_root.join(&rel);
+    if !abs.exists() {
+        return Err(anyhow!("File not found: {rel}"));
+    }
+
+    let result = session.request(
+        "unitycli/replaceSymbolBody",
+        json!({
+            "relative": rel,
+            "namePath": name_path,
+            "body": body,
+            "apply": apply
+        }),
+    )?;
+
+    Ok(wrap_lsp_write_result(result))
+}
+
+fn handle_insert_symbol(
+    session: &mut LspSession,
+    project_root: &Path,
+    params: &Value,
+    after: bool,
+) -> Result<Value> {
+    let tool_name = if after {
+        "insert_after_symbol"
+    } else {
+        "insert_before_symbol"
+    };
+    let rel = require_relative_path(params, tool_name)?;
+    let name_path = require_name_path(params, tool_name)?;
+    let text = params
+        .get("text")
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow!("{tool_name} requires `text`"))?;
+    let apply = get_apply(params);
+
+    let abs = project_root.join(&rel);
+    if !abs.exists() {
+        return Err(anyhow!("File not found: {rel}"));
+    }
+
+    let method = if after {
+        "unitycli/insertAfterSymbol"
+    } else {
+        "unitycli/insertBeforeSymbol"
+    };
+
+    let result = session.request(
+        method,
+        json!({
+            "relative": rel,
+            "namePath": name_path,
+            "text": text,
+            "apply": apply
+        }),
+    )?;
+
+    Ok(wrap_lsp_write_result(result))
+}
+
+fn handle_remove_symbol(
+    session: &mut LspSession,
+    project_root: &Path,
+    params: &Value,
+) -> Result<Value> {
+    let rel = require_relative_path(params, "remove_symbol")?;
+    let name_path = require_name_path(params, "remove_symbol")?;
+    let apply = get_apply(params);
+    let fail_on_references = params.get("failOnReferences").and_then(Value::as_bool);
+    let remove_empty_file = params
+        .get("removeEmptyFile")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+
+    let abs = project_root.join(&rel);
+    if !abs.exists() {
+        return Err(anyhow!("File not found: {rel}"));
+    }
+
+    let request = build_remove_symbol_request(
+        &rel,
+        &name_path,
+        apply,
+        fail_on_references,
+        remove_empty_file,
+    );
+
+    let result = session.request("unitycli/removeSymbol", request)?;
+
+    Ok(wrap_lsp_write_result(result))
+}
+
+fn build_remove_symbol_request(
+    rel: &str,
+    name_path: &str,
+    apply: bool,
+    fail_on_references: Option<bool>,
+    remove_empty_file: bool,
+) -> Value {
+    let mut request = json!({
+        "relative": rel,
+        "namePath": name_path,
+        "apply": apply,
+        "removeEmptyFile": remove_empty_file
+    });
+    if let Some(value) = fail_on_references {
+        request["failOnReferences"] = json!(value);
+    }
+    request
+}
+
+fn handle_validate_text_edits(
+    session: &mut LspSession,
+    project_root: &Path,
+    params: &Value,
+) -> Result<Value> {
+    let rel = require_relative_path(params, "validate_text_edits")?;
+    let new_text = params
+        .get("newText")
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow!("validate_text_edits requires `newText`"))?;
+
+    let abs = project_root.join(&rel);
+    if !abs.exists() {
+        return Err(anyhow!("File not found: {rel}"));
+    }
+
+    let result = session.request(
+        "unitycli/validateTextEdits",
+        json!({
+            "relative": rel,
+            "newText": new_text
+        }),
+    )?;
+
+    let mut response = json!({ "backend": "lsp" });
+    if let Some(diags) = result.get("diagnostics") {
+        response["diagnostics"] = diags.clone();
+        response["success"] = json!(true);
+    } else {
+        response["diagnostics"] = json!([]);
+        response["success"] = json!(true);
+    }
+    Ok(response)
+}
+
+fn wrap_lsp_write_result(result: Value) -> Value {
+    let mut response = result.clone();
+    if response.is_object() {
+        response
+            .as_object_mut()
+            .unwrap()
+            .insert("backend".to_string(), json!("lsp"));
+    }
+    response
 }
 
 fn collect_document_symbols(value: &Value, container: Option<&str>, out: &mut Vec<Value>) {
@@ -892,7 +1141,9 @@ fn read_message(reader: &mut BufReader<ChildStdout>) -> Result<Option<Value>> {
 #[cfg(test)]
 mod tests {
     use anyhow::anyhow;
+    use serde_json::Value;
 
+    use super::build_remove_symbol_request;
     use super::is_retryable_session_error;
     use super::normalize_rel_path;
 
@@ -928,5 +1179,32 @@ mod tests {
     fn retryable_session_error_ignores_argument_errors() {
         let error = anyhow!("find_symbol requires `name`");
         assert!(!is_retryable_session_error(&error));
+    }
+
+    #[test]
+    fn remove_symbol_request_omits_fail_on_references_when_unset() {
+        let request = build_remove_symbol_request(
+            "Assets/Scripts/Player.cs",
+            "Player/Foo",
+            false,
+            None,
+            false,
+        );
+        assert!(request.get("failOnReferences").is_none());
+    }
+
+    #[test]
+    fn remove_symbol_request_includes_fail_on_references_when_set() {
+        let request = build_remove_symbol_request(
+            "Assets/Scripts/Player.cs",
+            "Player/Foo",
+            true,
+            Some(false),
+            true,
+        );
+        assert_eq!(
+            request.get("failOnReferences").and_then(Value::as_bool),
+            Some(false)
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Updated `src/lsp.rs` remove-symbol request building to omit `failOnReferences` when unset so backend reference checks stay enabled by default.
- Updated `src/local_tools.rs` local LSP write fallback to execute directly in `auto`/`required` modes so actionable backend errors are not masked by a generic message.
- Updated `src/local_tools.rs` class generation to add `using UnityEngine;` for `MonoBehaviour` inheritance and added regression tests to keep generated Unity scripts compilable.

## Changes

- `src/lsp.rs`: Changed `handle_remove_symbol` to preserve backend defaults for `failOnReferences` and added request-construction tests.
- `src/local_tools.rs`: Changed `local_lsp_write` fallback behavior to propagate direct LSP errors in `auto`/`required` modes.
- `src/local_tools.rs`: Changed `local_create_class` to emit `using UnityEngine;` for `inherits: "MonoBehaviour"` and updated class-generation tests.

## Testing

- [x] `cargo fmt` — formatter completed successfully.
- [x] `cargo test` — 57 passed, 0 failed.

## Related Issues / Links

- #40

## Checklist

- [x] Tests added/updated
- [ ] Lint/format passed (`cargo clippy`, `cargo fmt`, `svelte-check`) — `cargo fmt` passed; `cargo clippy` and `svelte-check` were not run in this PR.
- [ ] Documentation updated (if user-facing change) — N/A: internal CLI/LSP behavior change only.
- [ ] Migration/backfill plan included (if schema/data change) — N/A: no schema or data changes.
- [x] CHANGELOG impact considered (breaking change flagged in commit)
