### PR TITLE
chore(tools): register csharp write tools and docs

### DIFF
--- a/.claude-plugin/plugins/unity-cli/skills/unity-csharp-edit/SKILL.md
+++ b/.claude-plugin/plugins/unity-cli/skills/unity-csharp-edit/SKILL.md
@@ -20,6 +20,25 @@ unity-cli raw get_symbols --json '{"path":"Assets/Scripts/Player.cs"}'
 unity-cli raw find_symbol --json '{"name":"Player","kind":"class","scope":"assets"}'
 unity-cli raw find_refs --json '{"name":"Player","kind":"class","scope":"assets"}'
 
+# Rename symbol (LSP)
+unity-cli raw rename_symbol --json '{"relative":"Assets/Scripts/Player.cs","namePath":"Player/Jump","newName":"Leap","apply":true}'
+
+# Replace method body (LSP)
+unity-cli raw replace_symbol_body --json '{"relative":"Assets/Scripts/Player.cs","namePath":"Player/Jump","body":"{ Debug.Log(\"jump\"); }","apply":true}'
+
+# Insert before/after symbol (LSP)
+unity-cli raw insert_before_symbol --json '{"relative":"Assets/Scripts/Player.cs","namePath":"Player/Jump","text":"public void Crouch() { }","apply":true}'
+unity-cli raw insert_after_symbol --json '{"relative":"Assets/Scripts/Player.cs","namePath":"Player/Jump","text":"public void Dash() { }","apply":true}'
+
+# Remove symbol (LSP)
+unity-cli raw remove_symbol --json '{"relative":"Assets/Scripts/Player.cs","namePath":"Player/Jump","apply":true,"failOnReferences":true}'
+
+# Validate C# text (LSP)
+unity-cli raw validate_text_edits --json '{"relative":"Assets/Scripts/Player.cs","newText":"using UnityEngine;\npublic class Player : MonoBehaviour { }"}'
+
+# Create a new class (local)
+unity-cli raw create_class --json '{"name":"EnemyAI","namespace":"Game.AI","inherits":"MonoBehaviour","folder":"Assets/Scripts/AI"}'
+
 # Read/search context
 unity-cli raw read --json '{"path":"Assets/Scripts/Player.cs","startLine":1,"endLine":120}'
 unity-cli raw search --json '{"pattern":"public void Jump","include":"Assets/**/*.cs"}'
@@ -28,8 +47,21 @@ unity-cli raw search --json '{"pattern":"public void Jump","include":"Assets/**/
 unity-cli raw get_compilation_state --json '{}'
 ```
 
+## LSP Write Tools
+
+All LSP write tools accept `apply` (boolean, default false):
+- `apply: false` — preview mode, returns diff without modifying files
+- `apply: true` — applies changes to disk
+
+The `namePath` parameter navigates nested symbols with `/` separators:
+- `"Player"` — top-level class
+- `"Player/Jump"` — method Jump inside class Player
+- `"Player/Config/MaxSpeed"` — field in nested type
+
 ## Tips
 
 - Run `update_index` after edits for accurate symbol lookup.
 - Use `get_compilation_state` to check for errors after changes.
-- Apply code edits via repository patching, then validate with `get_compilation_state`.
+- Preview changes with `apply: false` before applying.
+- Use `validate_text_edits` to check C# syntax before writing files.
+- `create_class` creates the file and directory structure atomically.

--- a/src/tool_catalog.rs
+++ b/src/tool_catalog.rs
@@ -85,6 +85,13 @@ pub const TOOL_NAMES: &[&str] = &[
     "search",
     "find_symbol",
     "get_symbols",
+    "rename_symbol",
+    "replace_symbol_body",
+    "insert_before_symbol",
+    "insert_after_symbol",
+    "remove_symbol",
+    "validate_text_edits",
+    "create_class",
     "get_project_settings",
     "update_project_settings",
     "get_command_stats",
@@ -112,7 +119,7 @@ mod tests {
 
     #[test]
     fn tool_catalog_keeps_manifest_parity_count() {
-        assert_eq!(TOOL_NAMES.len(), 101);
+        assert_eq!(TOOL_NAMES.len(), 108);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Registered newly added C# LSP write tools in the CLI tool catalog so runtime lookup and manifest parity checks include them.
- Expanded the `unity-csharp-edit` skill guide with concrete command examples so contributors can use the new write/edit flow correctly.

## Changes

- `src/tool_catalog.rs`: Added `rename_symbol`, `replace_symbol_body`, `insert_before_symbol`, `insert_after_symbol`, `remove_symbol`, `validate_text_edits`, and `create_class` to `TOOL_NAMES` and updated the parity-count test from `101` to `108`.
- `.claude-plugin/plugins/unity-cli/skills/unity-csharp-edit/SKILL.md`: Added LSP write-tool usage examples, `apply` mode guidance, and `namePath` navigation notes.

## Testing

- [x] `cargo test tool_catalog::tests::tool_catalog_keeps_manifest_parity_count -- --nocapture` — parity test passes with updated tool count.

## Related Issues / Links

- #40

## Checklist

- [x] Tests added/updated
- [ ] Lint/format passed (`cargo clippy`, `cargo fmt`, `svelte-check`) — `cargo clippy`/`cargo fmt` were not rerun for this docs+catalog commit.
- [ ] Documentation updated (if user-facing change) — N/A: this PR itself is tool-catalog/skill documentation alignment.
- [ ] Migration/backfill plan included (if schema/data change) — N/A: no schema/data changes.
- [x] CHANGELOG impact considered (breaking change flagged in commit)
