### PR TITLE
fix(plugin): remove invalid manifest fields that broke marketplace install

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,6 @@
 {
-  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "unity-cli",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "description": "Claude Code skills for unity-cli command workflows and Unity CLI Bridge operations.",
   "owner": {
     "name": "akiojin",
@@ -11,7 +10,7 @@
     {
       "name": "unity-cli",
       "description": "Claude Code plugin for Rust-based unity-cli workflows.",
-      "version": "1.0.0",
+      "version": "0.1.0",
       "source": "./.claude-plugin/plugins/unity-cli",
       "category": "development"
     }

--- a/.claude-plugin/plugins/unity-cli/agents/unity-helper.md
+++ b/.claude-plugin/plugins/unity-cli/agents/unity-helper.md
@@ -1,9 +1,22 @@
 ---
 name: unity-helper
-description: Autonomous Unity helper that executes multi-step unity-cli workflows — scene setup, prefab creation, code scaffolding, and testing.
-when-to-use: Use when the user requests a multi-step Unity workflow such as creating a scene with objects, setting up prefabs, scaffolding C# scripts, or running play-mode tests.
+description: |
+  Autonomous Unity helper that executes multi-step unity-cli workflows — scene setup, prefab creation, code scaffolding, and testing.
+
+  <example>
+  Context: User wants to create a complete Unity scene with objects and components.
+  user: "Create a new scene called MainMenu with a Canvas, EventSystem, and a Start button"
+  assistant: "I'll use the unity-helper agent to set up the complete scene."
+  </example>
+
+  <example>
+  Context: User needs to scaffold C# scripts and run tests.
+  user: "Create a PlayerController script with movement methods and run the EditMode tests"
+  assistant: "I'll use the unity-helper agent to scaffold the code and run tests."
+  </example>
 allowed-tools: Bash, Read, Grep, Glob
-color: "#4CAF50"
+model: sonnet
+color: green
 ---
 
 # Unity Helper Agent

--- a/.claude-plugin/plugins/unity-cli/plugin.json
+++ b/.claude-plugin/plugins/unity-cli/plugin.json
@@ -1,24 +1,9 @@
 {
-  "$schema": "https://anthropic.com/claude-code/plugin.schema.json",
   "name": "unity-cli",
   "version": "0.1.0",
   "description": "Claude Code plugin providing skills for Rust-based unity-cli workflows.",
-  "skills": [
-    "skills/unity-cli-usage/SKILL.md",
-    "skills/unity-scene-create/SKILL.md",
-    "skills/unity-scene-inspect/SKILL.md",
-    "skills/unity-gameobject-edit/SKILL.md",
-    "skills/unity-prefab-workflow/SKILL.md",
-    "skills/unity-asset-management/SKILL.md",
-    "skills/unity-addressables/SKILL.md",
-    "skills/unity-csharp-navigate/SKILL.md",
-    "skills/unity-csharp-edit/SKILL.md",
-    "skills/unity-playmode-testing/SKILL.md",
-    "skills/unity-input-system/SKILL.md",
-    "skills/unity-ui-automation/SKILL.md",
-    "skills/unity-editor-tools/SKILL.md"
-  ],
-  "agents": [
-    "agents/unity-helper.md"
-  ]
+  "author": {
+    "name": "akiojin",
+    "url": "https://github.com/akiojin"
+  }
 }

--- a/README.de.md
+++ b/README.de.md
@@ -26,8 +26,18 @@ Einige Code Tools (`read`, `search`, `find_symbol`, `find_refs` usw.) laufen lok
 
 ### Empfohlen: Claude Code Plugin
 
-Installieren Sie das `unity-cli` Plugin aus dem Claude Code Marketplace.
+Installieren Sie das `unity-cli` Plugin aus dem Claude Code Marketplace:
+
+```bash
+/plugin marketplace add akiojin/unity-cli
+```
+
 Wenn `cargo` verfugbar ist, kann das Plugin Setup `unity-cli` automatisch installieren oder aktualisieren.
+
+### Codex Skills
+
+Wenn Sie dieses Repository mit Codex verwenden, sind Skills uber `.codex/skills/` verfugbar (Symlinks zur Plugin Quelle).
+Es ist keine zusatzliche Einrichtung erforderlich — klonen Sie einfach das Repository.
 
 ### Manuelle Installation
 

--- a/README.es.md
+++ b/README.es.md
@@ -26,8 +26,18 @@ Algunas herramientas de codigo (`read`, `search`, `find_symbol`, `find_refs`, et
 
 ### Recomendado: plugin de Claude Code
 
-Instala el plugin `unity-cli` desde Claude Code Marketplace.
+Instala el plugin `unity-cli` desde Claude Code Marketplace:
+
+```bash
+/plugin marketplace add akiojin/unity-cli
+```
+
 Si `cargo` esta disponible, la configuracion del plugin puede instalar o actualizar `unity-cli` automaticamente.
+
+### Codex Skills
+
+Al usar este repositorio con Codex, los skills estan disponibles a traves de `.codex/skills/` (enlaces simbolicos a la fuente del plugin).
+No se requiere configuracion adicional — solo clona el repositorio.
 
 ### Instalacion manual
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -26,8 +26,18 @@ Certains outils code (`read`, `search`, `find_symbol`, `find_refs`, etc.) s exec
 
 ### Recommande: plugin Claude Code
 
-Installez le plugin `unity-cli` depuis la Marketplace de Claude Code.
+Installez le plugin `unity-cli` depuis la Marketplace de Claude Code:
+
+```bash
+/plugin marketplace add akiojin/unity-cli
+```
+
 Si `cargo` est disponible, l installation du plugin peut installer ou mettre a jour automatiquement `unity-cli`.
+
+### Codex Skills
+
+Lorsque vous utilisez ce depot avec Codex, les skills sont disponibles via `.codex/skills/` (liens symboliques vers la source du plugin).
+Aucune configuration supplementaire n est necessaire — il suffit de cloner le depot.
 
 ### Installation manuelle
 

--- a/README.it.md
+++ b/README.it.md
@@ -26,8 +26,18 @@ Alcuni strumenti di codice (`read`, `search`, `find_symbol`, `find_refs`, ecc.) 
 
 ### Consigliato: plugin Claude Code
 
-Installa il plugin `unity-cli` dal Claude Code Marketplace.
+Installa il plugin `unity-cli` dal Claude Code Marketplace:
+
+```bash
+/plugin marketplace add akiojin/unity-cli
+```
+
 Se `cargo` e disponibile, il setup del plugin puo installare o aggiornare automaticamente `unity-cli`.
+
+### Codex Skills
+
+Quando si utilizza questo repository con Codex, le skill sono disponibili tramite `.codex/skills/` (link simbolici alla sorgente del plugin).
+Non e necessaria alcuna configurazione aggiuntiva — basta clonare il repository.
 
 ### Installazione manuale
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -26,8 +26,18 @@ Claude Code
 
 ### 推奨: Claude Code プラグイン
 
-Claude Code Marketplace から `unity-cli` プラグインをインストールします。
+Claude Code Marketplace から `unity-cli` プラグインをインストールします:
+
+```bash
+/plugin marketplace add akiojin/unity-cli
+```
+
 `cargo` が利用可能な環境では、プラグインセットアップ時に `unity-cli` を自動インストールまたは更新できます。
+
+### Codex スキル
+
+Codex でこのリポジトリを利用する場合、`.codex/skills/` にスキルのシンボリックリンクが配置済みです。
+リポジトリをクローンするだけで追加セットアップは不要です。
 
 ### 手動インストール
 

--- a/README.md
+++ b/README.md
@@ -26,8 +26,18 @@ Some code tools (`read`, `search`, `find_symbol`, `find_refs`, etc.) run locally
 
 ### Recommended: Claude Code Plugin
 
-Install the `unity-cli` plugin from Claude Code Marketplace.
+Install the `unity-cli` plugin from Claude Code Marketplace:
+
+```bash
+/plugin marketplace add akiojin/unity-cli
+```
+
 When `cargo` is available, plugin setup can install or update `unity-cli` automatically.
+
+### Codex Skills
+
+When using this repository with Codex, skills are available via `.codex/skills/` (symlinks to the plugin source).
+No additional setup is required — just clone the repository.
 
 ### Manual Install
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -26,8 +26,18 @@ Claude Code
 
 ### 推荐: Claude Code 插件
 
-从 Claude Code Marketplace 安装 `unity-cli` 插件。
+从 Claude Code Marketplace 安装 `unity-cli` 插件:
+
+```bash
+/plugin marketplace add akiojin/unity-cli
+```
+
 如果环境中可用 `cargo`，插件安装流程可自动安装或更新 `unity-cli`。
+
+### Codex Skills
+
+使用 Codex 时，`.codex/skills/` 中已提供指向插件源的符号链接。
+只需克隆仓库即可，无需额外配置。
 
 ### 手动安装
 


### PR DESCRIPTION
## Summary

- Remove `$schema`, `skills`, `agents` fields from `plugin.json` that Claude Code's validator rejected, switching to the minimal manifest pattern with directory auto-discovery
- Remove `$schema` from `marketplace.json` and sync version to `0.1.0`
- Fix agent frontmatter: replace non-standard `when-to-use` with `<example>` blocks, hex color with named color, add explicit `model`
- Add explicit `/plugin marketplace add akiojin/unity-cli` command and Codex Skills section to all 7 READMEs

Closes #57

## Test plan

- [x] `python3 -c "import json; json.load(open('plugin.json'))"` — valid JSON
- [x] `python3 -c "import json; json.load(open('marketplace.json'))"` — valid JSON
- [x] `skills/` and `agents/` directories present for auto-discovery
- [x] Plugin-validator agent passed with no critical issues
- [ ] `/plugin marketplace add akiojin/unity-cli` installs successfully after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)