### PR TITLE
feat(auto-update): add managed daemon auto-update

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -234,27 +234,33 @@ jobs:
         with:
           path: artifacts
 
-      - name: Generate LSP manifest
+      - name: Generate managed binary manifests
         env:
           TAG: ${{ needs.create-tag.outputs.tag }}
           VERSION: ${{ needs.create-tag.outputs.version }}
           REPO: ${{ github.repository }}
         run: |
-          manifest="{\"version\":\"${VERSION}\",\"assets\":{"
-          first=true
-          for file in artifacts/csharp-lsp-*/csharp-lsp-*; do
-            name="$(basename "$file")"
-            # extract RID from artifact name: csharp-lsp-linux-x64 -> linux-x64
-            rid="${name#csharp-lsp-}"
-            sha="$(sha256sum "$file" | cut -d' ' -f1)"
-            url="https://github.com/${REPO}/releases/download/${TAG}/${name}"
-            if [ "$first" = true ]; then first=false; else manifest="${manifest},"; fi
-            manifest="${manifest}\"${rid}\":{\"url\":\"${url}\",\"sha256\":\"${sha}\"}"
-          done
-          manifest="${manifest}}}"
-          echo "$manifest" | python3 -m json.tool > artifacts/csharp-lsp-manifest.json
-          echo "Generated manifest:"
-          cat artifacts/csharp-lsp-manifest.json
+          generate_manifest() {
+            prefix="$1"
+            output="$2"
+            manifest="{\"version\":\"${VERSION}\",\"assets\":{"
+            first=true
+            for file in artifacts/${prefix}-*/${prefix}-*; do
+              name="$(basename "$file")"
+              rid="${name#${prefix}-}"
+              sha="$(sha256sum "$file" | cut -d' ' -f1)"
+              url="https://github.com/${REPO}/releases/download/${TAG}/${name}"
+              if [ "$first" = true ]; then first=false; else manifest="${manifest},"; fi
+              manifest="${manifest}\"${rid}\":{\"url\":\"${url}\",\"sha256\":\"${sha}\"}"
+            done
+            manifest="${manifest}}}"
+            echo "$manifest" | python3 -m json.tool > "artifacts/${output}"
+            echo "Generated ${output}:"
+            cat "artifacts/${output}"
+          }
+
+          generate_manifest "unity-cli" "unity-cli-manifest.json"
+          generate_manifest "csharp-lsp" "csharp-lsp-manifest.json"
 
       - name: Upload assets to GitHub Release
         uses: softprops/action-gh-release@v2
@@ -265,6 +271,7 @@ jobs:
             artifacts/unity-cli-linux-arm64/unity-cli-linux-arm64
             artifacts/unity-cli-macos-arm64/unity-cli-macos-arm64
             artifacts/unity-cli-windows-x64.exe/unity-cli-windows-x64.exe
+            artifacts/unity-cli-manifest.json
             artifacts/csharp-lsp-linux-x64/csharp-lsp-linux-x64
             artifacts/csharp-lsp-linux-arm64/csharp-lsp-linux-arm64
             artifacts/csharp-lsp-osx-arm64/csharp-lsp-osx-arm64

--- a/README.ja.md
+++ b/README.ja.md
@@ -72,6 +72,16 @@ https://github.com/akiojin/unity-cli.git?path=UnityCliBridge/Packages/unity-cli-
 unity-cli system ping
 ```
 
+managed バイナリの確認と更新:
+
+```bash
+unity-cli cli doctor
+unity-cli cli install
+```
+
+`unityd` と `lspd` は daemon 起動時に managed `unity-cli` / C# LSP バイナリを自動更新します。
+managed copy は `UNITY_CLI_TOOLS_ROOT`（未指定時は OS 既定の tools ディレクトリ）配下に配置され、確認プロンプトなしで更新されます。
+
 ## スキル (13)
 
 | カテゴリ | スキル |

--- a/README.md
+++ b/README.md
@@ -72,6 +72,16 @@ Connection check:
 unity-cli system ping
 ```
 
+Managed binary maintenance:
+
+```bash
+unity-cli cli doctor
+unity-cli cli install
+```
+
+`unityd` and `lspd` automatically refresh their managed `unity-cli` / C# LSP binaries on daemon startup.
+The managed copies live under `UNITY_CLI_TOOLS_ROOT` (or the OS default tools directory) and are updated without an interactive confirmation prompt.
+
 ## Skills (13)
 
 | Category | Skills |

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -17,7 +17,7 @@ Run the publish script from the repository root:
 5. Commits the version sync, creates `vX.Y.Z`, and runs `cargo publish`
 6. Pushes the release commit and tag
 
-After the push, GitHub Actions `release.yml` builds the release binaries and uploads the GitHub Release assets.
+After the push, GitHub Actions `release.yml` builds the release binaries, generates managed-binary manifests, and uploads the GitHub Release assets.
 
 ## Tag Convention
 
@@ -60,6 +60,7 @@ Jobs:
 | `create-tag` | Creates the release tag if it does not exist yet |
 | `build` | Matrix build for `unity-cli` release binaries |
 | `build-lsp` | Matrix build for the bundled C# LSP binaries |
+| `upload-release` manifest step | Generates `unity-cli-manifest.json` and `csharp-lsp-manifest.json` with RID-specific URLs and SHA-256 digests |
 | `upload-release` | Uploads all built artifacts to the GitHub Release |
 
 Release artifacts include:
@@ -68,6 +69,7 @@ Release artifacts include:
 - `unity-cli-linux-arm64`
 - `unity-cli-macos-arm64`
 - `unity-cli-windows-x64.exe`
+- `unity-cli-manifest.json`
 - `csharp-lsp-linux-x64`
 - `csharp-lsp-linux-arm64`
 - `csharp-lsp-osx-arm64`

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -11,12 +11,19 @@ Snapshot date: `2026-03-06`
 | `system` | `ping` |
 | `scene` | `create` |
 | `instances` | `list`, `set-active` |
+| `cli` | `install`, `doctor` |
 | `lsp` | `install`, `doctor` |
 | `lspd` | `start`, `stop`, `status` |
 | `unityd` | `start`, `stop`, `status` |
 | `batch` | (batch command execution) |
 
 Use `raw` for full command coverage when no typed subcommand exists.
+
+Managed binary notes:
+
+- `cli install` downloads or refreshes the managed `unity-cli` copy under `UNITY_CLI_TOOLS_ROOT` (or the OS default tools directory).
+- `cli doctor` reports the managed `unity-cli` path, local version, latest release metadata, and whether an update is pending.
+- `unityd` and `lspd` automatically refresh managed binaries on daemon startup without an interactive confirmation step.
 
 Global options:
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -62,6 +62,10 @@ pub enum Command {
         #[command(subcommand)]
         command: LspCommand,
     },
+    Cli {
+        #[command(subcommand)]
+        command: CliCommand,
+    },
     Lspd {
         #[command(subcommand)]
         command: LspdCommand,
@@ -147,6 +151,15 @@ pub enum InstancesCommand {
 #[derive(Debug, Subcommand)]
 pub enum LspCommand {
     Install,
+    Doctor,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum CliCommand {
+    Install {
+        #[arg(long, default_value_t = false)]
+        force: bool,
+    },
     Doctor,
 }
 

--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -2004,6 +2004,7 @@ while True:
                 .to_str()
                 .expect("tools root path should be valid UTF-8"),
         );
+        let _skip_updates = EnvVarGuard::set("UNITY_CLI_TEST_SKIP_MANAGED_UPDATE", "1");
         let params = json!({"path":"Assets/Scripts/Player.cs"});
 
         std::env::set_var("UNITY_CLI_LSP_MODE", "off");

--- a/src/lsp_manager.rs
+++ b/src/lsp_manager.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::env;
 use std::fs;
 use std::io::{self, Read, Write};
@@ -14,8 +15,41 @@ const DOWNLOAD_TIMEOUT_SECS: u64 = 30;
 const HTTP_MAX_ATTEMPTS: usize = 3;
 const HTTP_RETRY_BASE_DELAY_MILLIS: u64 = 250;
 const USER_AGENT_VALUE: &str = "unity-cli";
-const MANIFEST_REPOS: &[&str] = &["akiojin/unity-cli"];
 const GITHUB_TOKEN_ENV_VARS: &[&str] = &["GITHUB_TOKEN", "GH_TOKEN"];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ManagedBinary {
+    CSharpLsp,
+    UnityCli,
+}
+
+#[derive(Debug, Clone)]
+pub struct ManagedBinaryStatus {
+    pub managed_binary: ManagedBinary,
+    pub rid: &'static str,
+    pub binary_path: PathBuf,
+    pub binary_exists: bool,
+    pub local_version: Option<String>,
+    pub latest: Option<LatestVersion>,
+    pub latest_error: Option<String>,
+    pub update_available: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct LatestVersion {
+    pub repo: String,
+    pub tag: String,
+    pub version: String,
+}
+
+#[derive(Debug, Clone)]
+struct ManagedBinarySpec {
+    key: &'static str,
+    install_subdir: &'static str,
+    manifest_name: &'static str,
+    executable_name: &'static str,
+    repos: &'static [&'static str],
+}
 
 #[derive(Debug, Deserialize)]
 struct ReleaseInfo {
@@ -23,17 +57,80 @@ struct ReleaseInfo {
 }
 
 #[derive(Debug, Deserialize)]
-struct LspManifest {
+struct ReleaseManifest {
     #[serde(default)]
     version: Option<String>,
     #[serde(default)]
-    assets: std::collections::HashMap<String, LspAsset>,
+    assets: HashMap<String, ReleaseAsset>,
 }
 
-#[derive(Debug, Deserialize)]
-struct LspAsset {
+#[derive(Debug, Clone, Deserialize)]
+struct ReleaseAsset {
     url: String,
     sha256: String,
+}
+
+#[derive(Debug, Clone)]
+struct LatestRelease {
+    repo: String,
+    tag: String,
+    version: String,
+    asset: ReleaseAsset,
+}
+
+impl ManagedBinary {
+    fn spec(self) -> ManagedBinarySpec {
+        match self {
+            Self::CSharpLsp => ManagedBinarySpec {
+                key: "csharp-lsp",
+                install_subdir: "csharp-lsp",
+                manifest_name: "csharp-lsp-manifest.json",
+                executable_name: if cfg!(target_os = "windows") {
+                    "server.exe"
+                } else {
+                    "server"
+                },
+                repos: &["akiojin/unity-cli"],
+            },
+            Self::UnityCli => ManagedBinarySpec {
+                key: "unity-cli",
+                install_subdir: "unity-cli",
+                manifest_name: "unity-cli-manifest.json",
+                executable_name: if cfg!(target_os = "windows") {
+                    "unity-cli.exe"
+                } else {
+                    "unity-cli"
+                },
+                repos: &["akiojin/unity-cli"],
+            },
+        }
+    }
+}
+
+impl ManagedBinaryStatus {
+    pub fn to_json(&self) -> Value {
+        let latest = self.latest.as_ref().map(|latest| {
+            json!({
+                "repo": latest.repo,
+                "tag": latest.tag,
+                "version": latest.version
+            })
+        });
+
+        json!({
+            "success": true,
+            "managed": true,
+            "key": self.managed_binary.spec().key,
+            "rid": self.rid,
+            "binaryPath": self.binary_path.to_string_lossy().to_string(),
+            "managedBinaryPath": self.binary_path.to_string_lossy().to_string(),
+            "binaryExists": self.binary_exists,
+            "localVersion": self.local_version,
+            "latest": latest,
+            "latestError": self.latest_error,
+            "updateAvailable": self.update_available
+        })
+    }
 }
 
 pub fn detect_rid() -> &'static str {
@@ -56,12 +153,9 @@ pub fn detect_rid() -> &'static str {
     }
 }
 
+#[cfg(test)]
 pub fn executable_name() -> &'static str {
-    if cfg!(target_os = "windows") {
-        "server.exe"
-    } else {
-        "server"
-    }
+    ManagedBinary::CSharpLsp.spec().executable_name
 }
 
 pub fn tools_root() -> Result<PathBuf> {
@@ -73,19 +167,68 @@ pub fn tools_root() -> Result<PathBuf> {
 }
 
 pub fn install_dir() -> Result<PathBuf> {
-    Ok(tools_root()?.join("csharp-lsp").join(detect_rid()))
+    install_dir_for(ManagedBinary::CSharpLsp)
 }
 
+#[cfg(test)]
 pub fn binary_path() -> Result<PathBuf> {
-    Ok(install_dir()?.join(executable_name()))
+    binary_path_for(ManagedBinary::CSharpLsp)
 }
 
+#[cfg(test)]
 pub fn version_path() -> Result<PathBuf> {
-    Ok(install_dir()?.join("VERSION"))
+    version_path_for(ManagedBinary::CSharpLsp)
 }
 
+#[cfg(test)]
 pub fn read_local_version() -> Option<String> {
-    let path = version_path().ok()?;
+    read_local_version_for(ManagedBinary::CSharpLsp)
+}
+
+pub fn cli_install_latest(force_download: bool) -> Result<Value> {
+    Ok(install_latest_for(ManagedBinary::UnityCli, force_download)?.to_json())
+}
+
+pub fn cli_doctor() -> Result<Value> {
+    Ok(doctor_for(ManagedBinary::UnityCli)?.to_json())
+}
+
+pub fn cli_status() -> Result<ManagedBinaryStatus> {
+    inspect_for(ManagedBinary::UnityCli)
+}
+
+pub fn lsp_status() -> Result<ManagedBinaryStatus> {
+    inspect_for(ManagedBinary::CSharpLsp)
+}
+
+pub fn ensure_latest_cli_for_daemon() -> Result<ManagedBinaryStatus> {
+    ensure_latest_for(ManagedBinary::UnityCli, false, true)
+}
+
+pub fn ensure_latest_lsp_for_daemon() -> Result<ManagedBinaryStatus> {
+    ensure_latest_for(ManagedBinary::CSharpLsp, false, true)
+}
+
+pub fn lsp_install_latest(force_download: bool) -> Result<ManagedBinaryStatus> {
+    install_latest_for(ManagedBinary::CSharpLsp, force_download)
+}
+
+fn install_dir_for(managed_binary: ManagedBinary) -> Result<PathBuf> {
+    Ok(tools_root()?
+        .join(managed_binary.spec().install_subdir)
+        .join(detect_rid()))
+}
+
+fn binary_path_for(managed_binary: ManagedBinary) -> Result<PathBuf> {
+    Ok(install_dir_for(managed_binary)?.join(managed_binary.spec().executable_name))
+}
+
+fn version_path_for(managed_binary: ManagedBinary) -> Result<PathBuf> {
+    Ok(install_dir_for(managed_binary)?.join("VERSION"))
+}
+
+fn read_local_version_for(managed_binary: ManagedBinary) -> Option<String> {
+    let path = version_path_for(managed_binary).ok()?;
     fs::read_to_string(path)
         .ok()
         .map(|value| value.trim().to_string())
@@ -93,68 +236,128 @@ pub fn read_local_version() -> Option<String> {
 }
 
 pub fn ensure_local(force_download: bool) -> Result<PathBuf> {
-    let path = binary_path()?;
+    ensure_local_for(ManagedBinary::CSharpLsp, force_download)
+}
+
+fn ensure_local_for(managed_binary: ManagedBinary, force_download: bool) -> Result<PathBuf> {
+    let path = binary_path_for(managed_binary)?;
     if path.exists() && !force_download {
         return Ok(path);
     }
 
-    download_latest_binary(&path)
+    let status = install_latest_for(managed_binary, true)?;
+    Ok(status.binary_path)
 }
 
 pub fn install_latest() -> Result<Value> {
-    let binary = ensure_local(true)?;
-    Ok(json!({
-        "success": true,
-        "rid": detect_rid(),
-        "binaryPath": binary.to_string_lossy().to_string(),
-        "version": read_local_version()
-    }))
+    Ok(lsp_install_latest(true)?.to_json())
 }
 
 pub fn doctor() -> Result<Value> {
-    let rid = detect_rid().to_string();
-    let root = tools_root()?;
-    let binary = binary_path()?;
-    let version = read_local_version();
-
-    let latest = fetch_latest_manifest().ok().map(|(manifest, repo, tag)| {
-        json!({
-            "repo": repo,
-            "tag": tag,
-            "version": manifest.version
-        })
-    });
-
-    Ok(json!({
-        "success": true,
-        "rid": rid,
-        "toolsRoot": root.to_string_lossy().to_string(),
-        "binaryPath": binary.to_string_lossy().to_string(),
-        "binaryExists": binary.exists(),
-        "localVersion": version,
-        "latest": latest
-    }))
+    Ok(doctor_for(ManagedBinary::CSharpLsp)?.to_json())
 }
 
-fn download_latest_binary(dest: &Path) -> Result<PathBuf> {
-    let rid = detect_rid();
-    let (manifest, _repo, tag) = fetch_latest_manifest()?;
-    let asset = manifest
-        .assets
-        .get(rid)
-        .ok_or_else(|| anyhow!("manifest missing asset for RID: {rid}"))?;
+fn inspect_for(managed_binary: ManagedBinary) -> Result<ManagedBinaryStatus> {
+    let binary_path = binary_path_for(managed_binary)?;
+    Ok(ManagedBinaryStatus {
+        managed_binary,
+        rid: detect_rid(),
+        binary_exists: binary_path.exists(),
+        local_version: read_local_version_for(managed_binary),
+        latest: None,
+        latest_error: None,
+        update_available: false,
+        binary_path,
+    })
+}
 
+fn doctor_for(managed_binary: ManagedBinary) -> Result<ManagedBinaryStatus> {
+    let mut status = inspect_for(managed_binary)?;
+    match fetch_latest_release(managed_binary) {
+        Ok(latest) => {
+            status.update_available =
+                status.local_version.as_deref() != Some(latest.version.as_str());
+            status.latest = Some(LatestVersion {
+                repo: latest.repo,
+                tag: latest.tag,
+                version: latest.version,
+            });
+        }
+        Err(error) => {
+            status.latest_error = Some(error.to_string());
+        }
+    }
+    Ok(status)
+}
+
+fn install_latest_for(
+    managed_binary: ManagedBinary,
+    force_download: bool,
+) -> Result<ManagedBinaryStatus> {
+    ensure_latest_for(managed_binary, force_download, false)
+}
+
+fn ensure_latest_for(
+    managed_binary: ManagedBinary,
+    force_download: bool,
+    allow_stale_existing: bool,
+) -> Result<ManagedBinaryStatus> {
+    let mut status = inspect_for(managed_binary)?;
+    if should_skip_remote_checks_for_tests() {
+        if status.binary_exists || allow_stale_existing {
+            return Ok(status);
+        }
+        return Err(anyhow!(
+            "managed {} binary is missing while test remote checks are disabled",
+            managed_binary.spec().key
+        ));
+    }
+
+    match fetch_latest_release(managed_binary) {
+        Ok(latest) => {
+            status.update_available =
+                status.local_version.as_deref() != Some(latest.version.as_str());
+            status.latest = Some(LatestVersion {
+                repo: latest.repo.clone(),
+                tag: latest.tag.clone(),
+                version: latest.version.clone(),
+            });
+            if force_download || !status.binary_exists || status.update_available {
+                download_latest_binary(managed_binary, &latest, &status.binary_path)?;
+                status.binary_exists = true;
+                status.local_version = Some(latest.version);
+                status.update_available = false;
+                status.latest_error = None;
+            }
+            Ok(status)
+        }
+        Err(error) if allow_stale_existing && status.binary_exists => {
+            status.latest_error = Some(error.to_string());
+            Ok(status)
+        }
+        Err(error) => Err(error),
+    }
+}
+
+fn download_latest_binary(
+    managed_binary: ManagedBinary,
+    latest: &LatestRelease,
+    dest: &Path,
+) -> Result<PathBuf> {
     if let Some(parent) = dest.parent() {
         fs::create_dir_all(parent)
             .with_context(|| format!("Failed to create install directory: {}", parent.display()))?;
     }
 
     let tmp = dest.with_extension("download");
-    download_to(&asset.url, &tmp)?;
+    download_to(&latest.asset.url, &tmp)?;
     let actual = sha256_file(&tmp)?;
-    if !actual.eq_ignore_ascii_case(&asset.sha256) {
+    if !actual.eq_ignore_ascii_case(&latest.asset.sha256) {
         let _ = fs::remove_file(&tmp);
-        return Err(anyhow!("checksum mismatch for downloaded LSP binary"));
+        return Err(anyhow!(
+            "checksum mismatch for downloaded {} binary",
+            managed_binary.spec().key
+        ));
     }
 
     replace_file_atomic(&tmp, dest)?;
@@ -166,16 +369,17 @@ fn download_latest_binary(dest: &Path) -> Result<PathBuf> {
         fs::set_permissions(dest, permissions)?;
     }
 
-    let version = manifest
-        .version
-        .unwrap_or_else(|| tag.trim_start_matches('v').to_string());
-    write_local_version(&version)?;
-
+    write_local_version_for(managed_binary, &latest.version)?;
     Ok(dest.to_path_buf())
 }
 
+#[cfg(test)]
 fn write_local_version(version: &str) -> Result<()> {
-    let path = version_path()?;
+    write_local_version_for(ManagedBinary::CSharpLsp, version)
+}
+
+fn write_local_version_for(managed_binary: ManagedBinary, version: &str) -> Result<()> {
+    let path = version_path_for(managed_binary)?;
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)
             .with_context(|| format!("Failed to create VERSION directory: {}", parent.display()))?;
@@ -184,32 +388,51 @@ fn write_local_version(version: &str) -> Result<()> {
         .with_context(|| format!("Failed to write VERSION marker: {}", path.display()))
 }
 
-fn fetch_latest_manifest() -> Result<(LspManifest, String, String)> {
+fn fetch_latest_release(managed_binary: ManagedBinary) -> Result<LatestRelease> {
     let mut errors = Vec::new();
-    for repo in MANIFEST_REPOS {
-        match fetch_latest_manifest_for_repo(repo) {
-            Ok((manifest, tag)) => return Ok((manifest, (*repo).to_string(), tag)),
+    for repo in managed_binary.spec().repos {
+        match fetch_latest_release_for_repo(managed_binary, repo) {
+            Ok(release) => return Ok(release),
             Err(error) => errors.push(format!("{repo}: {error}")),
         }
     }
 
     Err(anyhow!(
-        "Failed to fetch csharp-lsp manifest from known repositories: {}",
+        "Failed to fetch {} manifest from known repositories: {}",
+        managed_binary.spec().key,
         errors.join(" | ")
     ))
 }
 
-fn fetch_latest_manifest_for_repo(repo: &str) -> Result<(LspManifest, String)> {
+fn fetch_latest_release_for_repo(
+    managed_binary: ManagedBinary,
+    repo: &str,
+) -> Result<LatestRelease> {
     let release_url = format!("https://api.github.com/repos/{repo}/releases/latest");
     let release: ReleaseInfo = get_json(&release_url)?;
 
     let tag = release.tag_name;
-    let manifest_url =
-        format!("https://github.com/{repo}/releases/download/{tag}/csharp-lsp-manifest.json");
+    let manifest_url = format!(
+        "https://github.com/{repo}/releases/download/{tag}/{}",
+        managed_binary.spec().manifest_name
+    );
 
-    let manifest: LspManifest = get_json(&manifest_url)?;
+    let manifest: ReleaseManifest = get_json(&manifest_url)?;
+    let version = manifest
+        .version
+        .unwrap_or_else(|| tag.trim_start_matches('v').to_string());
+    let asset = manifest
+        .assets
+        .get(detect_rid())
+        .cloned()
+        .ok_or_else(|| anyhow!("manifest missing asset for RID: {}", detect_rid()))?;
 
-    Ok((manifest, tag))
+    Ok(LatestRelease {
+        repo: repo.to_string(),
+        tag,
+        version,
+        asset,
+    })
 }
 
 fn download_to(url: &str, dest: &Path) -> Result<()> {
@@ -321,6 +544,16 @@ fn github_token_from_env() -> Option<String> {
         }
     }
     None
+}
+
+fn should_skip_remote_checks_for_tests() -> bool {
+    cfg!(test)
+        && matches!(
+            std::env::var("UNITY_CLI_TEST_SKIP_MANAGED_UPDATE")
+                .ok()
+                .as_deref(),
+            Some("1") | Some("true") | Some("yes")
+        )
 }
 
 fn get_json<T: for<'de> Deserialize<'de>>(url: &str) -> Result<T> {
@@ -499,6 +732,40 @@ mod tests {
     }
 
     #[test]
+    fn unity_cli_status_uses_managed_install_layout() {
+        let _guard = env_lock()
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        let dir = tempdir().expect("tempdir should succeed");
+        let _env = EnvVarGuard::set(
+            "UNITY_CLI_TOOLS_ROOT",
+            dir.path()
+                .to_str()
+                .expect("tempdir path should be valid UTF-8"),
+        );
+
+        let binary = binary_path_for(ManagedBinary::UnityCli).expect("binary path should resolve");
+        if let Some(parent) = binary.parent() {
+            fs::create_dir_all(parent).expect("binary parent directory should be created");
+        }
+        fs::write(&binary, b"managed-unity-cli").expect("binary fixture should be writable");
+        write_local_version_for(ManagedBinary::UnityCli, "0.3.0")
+            .expect("unity-cli version should be writable");
+
+        let status = cli_status().expect("cli status should succeed");
+        assert_eq!(status.binary_path, binary);
+        assert!(status.binary_exists);
+        assert_eq!(status.local_version.as_deref(), Some("0.3.0"));
+        let json = status.to_json();
+        assert_eq!(json["managed"], true);
+        assert_eq!(json["key"], "unity-cli");
+        assert_eq!(
+            json["managedBinaryPath"].as_str(),
+            Some(binary.to_string_lossy().as_ref())
+        );
+    }
+
+    #[test]
     fn read_local_version_returns_none_for_missing_or_blank_file() {
         let _guard = env_lock()
             .lock()
@@ -542,6 +809,34 @@ mod tests {
 
         let resolved = ensure_local(false).expect("existing binary should be reused");
         assert_eq!(resolved, binary);
+    }
+
+    #[test]
+    fn ensure_latest_for_can_skip_remote_checks_in_tests() {
+        let _guard = env_lock()
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        let dir = tempdir().expect("tempdir should succeed");
+        let _env = EnvVarGuard::set(
+            "UNITY_CLI_TOOLS_ROOT",
+            dir.path()
+                .to_str()
+                .expect("tempdir path should be valid UTF-8"),
+        );
+        let _skip = EnvVarGuard::set("UNITY_CLI_TEST_SKIP_MANAGED_UPDATE", "1");
+
+        let binary =
+            binary_path_for(ManagedBinary::UnityCli).expect("unity-cli binary path should resolve");
+        if let Some(parent) = binary.parent() {
+            fs::create_dir_all(parent).expect("binary parent directory should be created");
+        }
+        fs::write(&binary, b"managed-unity-cli").expect("binary fixture should be writable");
+
+        let status = ensure_latest_for(ManagedBinary::UnityCli, false, true)
+            .expect("skip flag should avoid remote fetch");
+        assert_eq!(status.binary_path, binary);
+        assert!(status.binary_exists);
+        assert!(status.latest.is_none());
     }
 
     #[test]

--- a/src/lspd.rs
+++ b/src/lspd.rs
@@ -42,8 +42,68 @@ enum ConnectionAction {
     Stop,
 }
 
+fn daemon_command_path() -> Result<PathBuf> {
+    Ok(lsp_manager::ensure_latest_cli_for_daemon()?.binary_path)
+}
+
+fn append_managed_status(payload: &mut Value) {
+    let Some(map) = payload.as_object_mut() else {
+        return;
+    };
+
+    if let Some(path) = std::env::current_exe()
+        .ok()
+        .map(|path| path.to_string_lossy().to_string())
+    {
+        map.insert("daemonBinaryPath".to_string(), Value::String(path));
+    }
+
+    if let Ok(cli_status) = lsp_manager::cli_status() {
+        map.insert(
+            "managedBinaryPath".to_string(),
+            Value::String(cli_status.binary_path.to_string_lossy().to_string()),
+        );
+        map.insert(
+            "localVersion".to_string(),
+            cli_status
+                .local_version
+                .clone()
+                .map(Value::String)
+                .unwrap_or(Value::Null),
+        );
+        map.insert(
+            "latest".to_string(),
+            cli_status
+                .to_json()
+                .get("latest")
+                .cloned()
+                .unwrap_or(Value::Null),
+        );
+        map.insert(
+            "updateAvailable".to_string(),
+            Value::Bool(cli_status.update_available),
+        );
+        map.insert("cli".to_string(), cli_status.to_json());
+    }
+
+    if let Ok(lsp_status) = lsp_manager::lsp_status() {
+        map.insert(
+            "binaryPath".to_string(),
+            Value::String(lsp_status.binary_path.to_string_lossy().to_string()),
+        );
+        map.insert(
+            "version".to_string(),
+            lsp_status
+                .local_version
+                .clone()
+                .map(Value::String)
+                .unwrap_or(Value::Null),
+        );
+        map.insert("lsp".to_string(), lsp_status.to_json());
+    }
+}
+
 pub fn start_background() -> Result<Value> {
-    let _ = lsp_manager::ensure_local(false)?;
     if let Ok(status) = status() {
         if status
             .get("running")
@@ -60,9 +120,10 @@ pub fn start_background() -> Result<Value> {
     }
 
     cleanup_stale_files();
+    let _ = lsp_manager::ensure_latest_lsp_for_daemon()?;
 
-    let exe = std::env::current_exe().context("Failed to resolve current executable path")?;
-    Command::new(exe)
+    let exe = daemon_command_path()?;
+    Command::new(&exe)
         .arg("lspd")
         .arg("serve")
         .stdin(Stdio::null())
@@ -111,23 +172,25 @@ pub fn stop() -> Result<Value> {
 }
 
 pub fn status() -> Result<Value> {
-    match request(DaemonRequest::Status) {
+    let mut value = match request(DaemonRequest::Status) {
         Ok(response) => {
             if response.ok {
-                Ok(response
+                response
                     .result
-                    .unwrap_or_else(|| json!({ "running": true })))
+                    .unwrap_or_else(|| json!({ "running": true }))
             } else {
-                Ok(json!({
+                json!({
                     "running": false,
                     "error": response.error.unwrap_or_else(|| "status failed".to_string())
-                }))
+                })
             }
         }
-        Err(_) => Ok(json!({
+        Err(_) => json!({
             "running": false
-        })),
-    }
+        }),
+    };
+    append_managed_status(&mut value);
+    Ok(value)
 }
 
 pub fn call_tool(tool_name: &str, params: &Value, project_root: &Path) -> Result<Value> {
@@ -221,13 +284,15 @@ fn handle_request(request: DaemonRequest) -> Result<(DaemonResponse, ConnectionA
         DaemonRequest::Status => Ok((
             DaemonResponse {
                 ok: true,
-                result: Some(json!({
-                    "running": true,
-                    "pid": std::process::id(),
-                    "rid": lsp_manager::detect_rid(),
-                    "binaryPath": lsp_manager::binary_path().ok().map(|path| path.to_string_lossy().to_string()),
-                    "version": lsp_manager::read_local_version()
-                })),
+                result: Some({
+                    let mut value = json!({
+                        "running": true,
+                        "pid": std::process::id(),
+                        "rid": lsp_manager::detect_rid(),
+                    });
+                    append_managed_status(&mut value);
+                    value
+                }),
                 error: None,
             },
             ConnectionAction::Continue,
@@ -641,6 +706,21 @@ mod tests {
                 .and_then(serde_json::Value::as_bool),
             Some(true)
         );
+        assert!(status_resp
+            .result
+            .as_ref()
+            .and_then(|v| v.get("managedBinaryPath"))
+            .is_some());
+        assert!(status_resp
+            .result
+            .as_ref()
+            .and_then(|v| v.get("cli"))
+            .is_some());
+        assert!(status_resp
+            .result
+            .as_ref()
+            .and_then(|v| v.get("lsp"))
+            .is_some());
         assert!(matches!(status_action, ConnectionAction::Continue));
 
         let (stop_resp, stop_action) = handle_request(DaemonRequest::Stop).expect("stop must work");

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,8 +19,8 @@ use std::path::PathBuf;
 use tracing_subscriber::EnvFilter;
 
 use crate::cli::{
-    Cli, Command, InstancesCommand, LspCommand, LspdCommand, OutputFormat, RawArgs, SceneCommand,
-    SystemCommand, ToolCommand, UnitydCommand,
+    Cli, CliCommand, Command, InstancesCommand, LspCommand, LspdCommand, OutputFormat, RawArgs,
+    SceneCommand, SystemCommand, ToolCommand, UnitydCommand,
 };
 use crate::config::RuntimeConfig;
 use crate::instances::{list_instances, set_active_instance};
@@ -164,6 +164,16 @@ async fn run_with_cli(cli: Cli) -> Result<()> {
             }
             LspCommand::Doctor => {
                 let value = lsp_manager::doctor()?;
+                print_value(&value, cli.output)?;
+            }
+        },
+        Command::Cli { command } => match command {
+            CliCommand::Install { force } => {
+                let value = lsp_manager::cli_install_latest(*force)?;
+                print_value(&value, cli.output)?;
+            }
+            CliCommand::Doctor => {
+                let value = lsp_manager::cli_doctor()?;
                 print_value(&value, cli.output)?;
             }
         },

--- a/src/unityd.rs
+++ b/src/unityd.rs
@@ -13,6 +13,7 @@ use thiserror::Error;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt};
 
 use crate::config::RuntimeConfig;
+use crate::lsp_manager;
 use crate::transport::UnityClient;
 
 const DEFAULT_IDLE_TIMEOUT_SECS: u64 = 600;
@@ -103,8 +104,7 @@ impl ConnectionPool {
 }
 
 fn tools_dir() -> Result<PathBuf> {
-    let home = dirs::home_dir().ok_or_else(|| anyhow!("Cannot determine home directory"))?;
-    let dir = home.join(".unity").join("tools");
+    let dir = lsp_manager::tools_root()?;
     fs::create_dir_all(&dir)
         .with_context(|| format!("Failed to create tools directory: {}", dir.display()))?;
     Ok(dir)
@@ -150,6 +150,51 @@ fn cleanup_stale_files() {
     }
 }
 
+fn daemon_command_path() -> Result<PathBuf> {
+    Ok(lsp_manager::ensure_latest_cli_for_daemon()?.binary_path)
+}
+
+fn append_cli_status(payload: &mut Value) {
+    let Some(map) = payload.as_object_mut() else {
+        return;
+    };
+
+    if let Some(path) = std::env::current_exe()
+        .ok()
+        .map(|path| path.to_string_lossy().to_string())
+    {
+        map.insert("daemonBinaryPath".to_string(), Value::String(path));
+    }
+
+    if let Ok(cli_status) = lsp_manager::cli_status() {
+        map.insert(
+            "managedBinaryPath".to_string(),
+            Value::String(cli_status.binary_path.to_string_lossy().to_string()),
+        );
+        map.insert(
+            "localVersion".to_string(),
+            cli_status
+                .local_version
+                .clone()
+                .map(Value::String)
+                .unwrap_or(Value::Null),
+        );
+        map.insert(
+            "latest".to_string(),
+            cli_status
+                .to_json()
+                .get("latest")
+                .cloned()
+                .unwrap_or(Value::Null),
+        );
+        map.insert(
+            "updateAvailable".to_string(),
+            Value::Bool(cli_status.update_available),
+        );
+        map.insert("cli".to_string(), cli_status.to_json());
+    }
+}
+
 pub fn start_background() -> Result<Value> {
     if let Ok(status) = status() {
         if status
@@ -168,8 +213,8 @@ pub fn start_background() -> Result<Value> {
 
     cleanup_stale_files();
 
-    let exe = std::env::current_exe().context("Failed to resolve current executable path")?;
-    Command::new(exe)
+    let exe = daemon_command_path()?;
+    Command::new(&exe)
         .arg("unityd")
         .arg("serve")
         .stdin(Stdio::null())
@@ -218,23 +263,25 @@ pub fn stop() -> Result<Value> {
 }
 
 pub fn status() -> Result<Value> {
-    match request(DaemonRequest::Status) {
+    let mut value = match request(DaemonRequest::Status) {
         Ok(response) => {
             if response.ok {
-                Ok(response
+                response
                     .result
-                    .unwrap_or_else(|| json!({ "running": true })))
+                    .unwrap_or_else(|| json!({ "running": true }))
             } else {
-                Ok(json!({
+                json!({
                     "running": false,
                     "error": response.error.unwrap_or_else(|| "status failed".to_string())
-                }))
+                })
             }
         }
-        Err(_) => Ok(json!({
+        Err(_) => json!({
             "running": false
-        })),
-    }
+        }),
+    };
+    append_cli_status(&mut value);
+    Ok(value)
 }
 
 pub async fn try_call_tool(
@@ -467,11 +514,15 @@ async fn handle_request(
         DaemonRequest::Status => Ok((
             DaemonResponse {
                 ok: true,
-                result: Some(json!({
+                result: Some({
+                    let mut value = json!({
                     "running": true,
                     "pid": std::process::id(),
                     "connections": pool.connections.len(),
-                })),
+                    });
+                    append_cli_status(&mut value);
+                    value
+                }),
                 error: None,
             },
             ConnectionAction::Continue,
@@ -737,23 +788,66 @@ mod tests {
 
     #[test]
     fn tools_dir_creates_directory() {
+        let _guard = env_lock()
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        let home = tempdir().expect("tempdir should succeed");
+        let _home = EnvVarGuard::set(
+            "HOME",
+            home.path()
+                .to_str()
+                .expect("tempdir path should be valid UTF-8"),
+        );
         let dir = tools_dir().expect("tools_dir should succeed");
         assert!(dir.exists());
         assert!(dir.is_dir());
-        assert!(dir.ends_with(".unity/tools"));
+        assert_eq!(
+            dir,
+            crate::lsp_manager::tools_root().expect("shared tools root should resolve")
+        );
     }
 
     #[test]
     fn pid_file_path_is_under_tools_dir() {
+        let _guard = env_lock()
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        let home = tempdir().expect("tempdir should succeed");
+        let _home = EnvVarGuard::set(
+            "HOME",
+            home.path()
+                .to_str()
+                .expect("tempdir path should be valid UTF-8"),
+        );
         let path = pid_file_path().expect("pid_file_path should succeed");
-        assert!(path.to_string_lossy().contains(".unity/tools/unityd.pid"));
+        assert_eq!(
+            path,
+            tools_dir()
+                .expect("tools dir should resolve")
+                .join("unityd.pid")
+        );
     }
 
     #[cfg(unix)]
     #[test]
     fn socket_path_is_under_tools_dir() {
+        let _guard = env_lock()
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        let home = tempdir().expect("tempdir should succeed");
+        let _home = EnvVarGuard::set(
+            "HOME",
+            home.path()
+                .to_str()
+                .expect("tempdir path should be valid UTF-8"),
+        );
         let path = socket_path().expect("socket_path should succeed");
-        assert!(path.to_string_lossy().contains(".unity/tools/unityd.sock"));
+        assert_eq!(
+            path,
+            tools_dir()
+                .expect("tools dir should resolve")
+                .join("unityd.sock")
+        );
     }
 
     #[test]
@@ -808,6 +902,16 @@ mod tests {
                     .and_then(serde_json::Value::as_bool),
                 Some(true)
             );
+            assert!(status_resp
+                .result
+                .as_ref()
+                .and_then(|v| v.get("managedBinaryPath"))
+                .is_some());
+            assert!(status_resp
+                .result
+                .as_ref()
+                .and_then(|v| v.get("cli"))
+                .is_some());
             assert!(matches!(status_action, ConnectionAction::Continue));
 
             let (stop_resp, stop_action) = handle_request(DaemonRequest::Stop, &mut pool)


### PR DESCRIPTION
## Summary

- Add a shared managed updater for `unity-cli` and the C# LSP so daemon startup can self-refresh without overwriting user-installed binaries.
- Route `unityd` and `lspd` through the managed `unity-cli` copy and surface version metadata so update state is diagnosable from status output.
- Extend the release workflow and docs with `unity-cli-manifest.json`, `unity-cli cli doctor`, and `unity-cli cli install` so the auto-update path is publishable and discoverable.

## Changes

- `src/lsp_manager.rs`: refactor the LSP-only downloader into a shared managed binary updater, add install/doctor/status APIs for `unity-cli` and `csharp-lsp`, and add test-only remote-skip coverage.
- `src/unityd.rs` and `src/lspd.rs`: start daemons from the managed `unity-cli` copy, unify tools-root usage, and include managed binary metadata in status responses.
- `src/cli.rs` and `src/main.rs`: add typed `unity-cli cli install` and `unity-cli cli doctor` commands.
- `.github/workflows/release.yml`: generate and upload `unity-cli-manifest.json` alongside `csharp-lsp-manifest.json`.
- `README.md`, `README.ja.md`, `docs/tools.md`, and `RELEASE.md`: document managed auto-update behavior and the new CLI entrypoints.
- `src/lsp.rs`: set a test-only skip flag so unit tests stay hermetic when daemon startup now checks managed updates.

## Testing

- [x] `cargo fmt --all` — completes successfully after formatting the updated Rust sources.
- [x] `cargo clippy --all-targets -- -D warnings` — exits successfully with no warnings.
- [x] `cargo test --all-targets` — passes with `205 passed; 0 failed`.

## Related Issues / Links

- None

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`, `svelte-check`) — `cargo fmt --all` and `cargo clippy --all-targets -- -D warnings` passed; `svelte-check` N/A: no Svelte code
- [x] Documentation updated (if user-facing change)
- [x] Migration/backfill plan included (if schema/data change) — N/A: no schema or data migration
- [x] CHANGELOG impact considered (breaking change flagged in commit) — non-breaking feature; next release notes should mention managed auto-update support

## Context

- `unityd` is bundled inside `unity-cli`, so supporting automatic daemon updates required a managed-copy strategy for the CLI itself instead of only refreshing the C# LSP payload.
- The release pipeline needed a published `unity-cli-manifest.json` before the runtime updater could resolve checksums and asset URLs for each RID.

## Risk / Impact

- **Affected areas**: daemon startup paths, managed tool storage under `UNITY_CLI_TOOLS_ROOT`, release asset generation, and daemon status JSON output.
- **Rollback plan**: revert this PR and cut a follow-up release without `unity-cli-manifest.json`; daemon startup will fall back to the pre-existing non-managed behavior.

## Notes

- `unity-cli` self-update becomes fully active after the first release that includes `unity-cli-manifest.json`; until then, `unity-cli cli doctor` will report the manifest as unavailable on current public releases.
