### PR TITLE
feat(skills): align unity skills with Anthropic guidance

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "name": "unity-cli",
   "version": "0.1.0",
-  "description": "Claude Code skills for unity-cli command workflows and Unity CLI Bridge operations.",
+  "description": "Claude Code skills for workflow-oriented unity-cli automation and Unity CLI Bridge operations.",
   "owner": {
     "name": "akiojin",
     "url": "https://github.com/akiojin"
@@ -9,7 +9,7 @@
   "plugins": [
     {
       "name": "unity-cli",
-      "description": "Claude Code plugin for Rust-based unity-cli workflows.",
+      "description": "Claude Code plugin for workflow-oriented Rust-based unity-cli automation.",
       "version": "0.1.0",
       "source": "./.claude-plugin/plugins/unity-cli",
       "category": "development"

--- a/.claude-plugin/plugins/unity-cli/plugin.json
+++ b/.claude-plugin/plugins/unity-cli/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "unity-cli",
   "version": "0.1.0",
-  "description": "Claude Code plugin providing skills for Rust-based unity-cli workflows.",
+  "description": "Claude Code plugin providing workflow-oriented skills for Rust-based unity-cli automation.",
   "author": {
     "name": "akiojin",
     "url": "https://github.com/akiojin"

--- a/.claude-plugin/plugins/unity-cli/skills/gh-skills-sync/SKILL.md
+++ b/.claude-plugin/plugins/unity-cli/skills/gh-skills-sync/SKILL.md
@@ -1,7 +1,11 @@
 ---
 name: gh-skills-sync
-description: Sync gh-* automation skills from a GitHub repository into global and project skill directories for Codex/Claude workflows.
+description: Sync the gh-* automation skills from the upstream skills repository into Codex and project skill directories. Use when the user asks to refresh, check, or pin `gh-fix-ci`, `gh-fix-issue`, `gh-pr`, or `gh-pr-check` in this repo or the global Codex install. Do not use for updating unity-cli workflow skills; edit those skill folders directly.
 allowed-tools: Bash, Read, Grep, Glob
+metadata:
+  author: akiojin
+  version: 0.2.0
+  category: maintenance
 ---
 
 # gh-skills-sync
@@ -12,6 +16,26 @@ Use this skill when asked to update or synchronize GitHub-related skills:
 - `gh-fix-issue`
 - `gh-pr`
 - `gh-pr-check`
+
+Read `references/sync-behavior.md` when you need details about source selection, backup behavior, or project-vs-global targeting.
+
+## Use When
+
+- The user wants to refresh the local copy of the `gh-*` automation skills.
+- The task is to check whether project and global copies are in sync.
+- The user wants to pin synchronization to a specific upstream ref.
+
+## Do Not Use When
+
+- The task is about editing `unity-cli` skills in `.claude-plugin/plugins/unity-cli/skills`.
+- The request is to use a `gh-*` skill rather than sync it.
+
+## Recommended Flow
+
+1. Run `--check` first when the user only asked for status or when the current state is unclear.
+2. Decide whether to target project skills, global skills, or both.
+3. Run the sync command with any required `--ref`.
+4. Re-run `--check` after changes and report what moved.
 
 ## Command
 
@@ -34,6 +58,12 @@ scripts/sync-gh-skills.sh --target project
 scripts/sync-gh-skills.sh --ref main
 ```
 
+## Examples
+
+- "Check whether our local `gh-*` skills are behind upstream."
+- "Update only the project copy of the GitHub automation skills."
+- "Sync the `gh-*` skills from a pinned upstream ref."
+
 ## Behavior
 
 - Default source repo: `akiojin/skills`
@@ -45,7 +75,9 @@ scripts/sync-gh-skills.sh --ref main
   - Prefer `skill-installer` if available.
   - Fallback to `git sparse-checkout` so it also works in Claude Code environments.
 
-## Post Sync
+## Common Issues
 
-- Verify consistency with `scripts/sync-gh-skills.sh --check`.
-- Restart Codex/Claude Code if updated skills are not reflected immediately.
+- The wrong target was updated: use `--target project` or the appropriate target selector before syncing.
+- The user only wanted a dry check: start with `--check`.
+- Updated skills do not appear immediately: restart Codex or Claude Code after the sync.
+- Use `scripts/sync-gh-skills.sh --check` after any update to verify consistency.

--- a/.claude-plugin/plugins/unity-cli/skills/gh-skills-sync/references/sync-behavior.md
+++ b/.claude-plugin/plugins/unity-cli/skills/gh-skills-sync/references/sync-behavior.md
@@ -1,0 +1,20 @@
+# Sync Behavior
+
+## Targets
+
+- Project sync updates `./.codex/skills`.
+- Global sync updates `${CODEX_HOME:-~/.codex}/skills`.
+- Choose the smallest target that satisfies the request.
+
+## Safe Sequence
+
+1. Run `scripts/sync-gh-skills.sh --check` if current state is unknown.
+2. Run the sync with the intended target and optional `--ref`.
+3. Re-run `--check`.
+4. Report which skills changed and where backups were written.
+
+## Failure Modes
+
+- A stale global install can mask project changes.
+- Backups live under `.backup/gh-sync-<timestamp>/`.
+- Restart the host tool if updated skills do not appear immediately.

--- a/.claude-plugin/plugins/unity-cli/skills/unity-addressables/SKILL.md
+++ b/.claude-plugin/plugins/unity-cli/skills/unity-addressables/SKILL.md
@@ -1,12 +1,35 @@
 ---
 name: unity-addressables
-description: Manage, build, and analyze Unity Addressables groups and content using unity-cli.
+description: Manage Unity Addressables groups and content with unity-cli. Use when the user asks to list or create groups, add or remove entries, build or clean Addressables content, or analyze and fix Addressables issues before a build. Do not use for generic asset import settings or material editing; use asset management for those tasks.
 allowed-tools: Bash, Read, Grep, Glob
+metadata:
+  author: akiojin
+  version: 0.2.0
+  category: assets
 ---
 
 # Addressables Operations
 
 Manage Addressable Asset groups, build content, and analyze bundles.
+Read `references/addressables-build-loop.md` when you need a safer order for group changes, analysis, and clean builds.
+
+## Use When
+
+- The user wants to manage Addressables groups or entries.
+- The task involves building or cleaning Addressables content.
+- The user wants an analysis pass or automatic issue fix before shipping content.
+
+## Do Not Use When
+
+- The task is about general asset import settings or dependency analysis outside Addressables.
+- The request is about scene object setup rather than content delivery.
+
+## Recommended Flow
+
+1. Inspect existing groups before creating or moving entries.
+2. Apply group or entry changes with `addressables_manage`.
+3. Run `addressables_analyze` before a build, and use `fix_issues` only when the reported changes are acceptable.
+4. Build with `addressables_build`, using `clean_build` when structure changed substantially.
 
 ## Commands
 
@@ -26,7 +49,15 @@ unity-cli raw addressables_analyze --json '{"action":"analyze"}'
 unity-cli raw addressables_analyze --json '{"action":"fix_issues"}'
 ```
 
-## Tips
+## Examples
 
-- Run `analyze` before `build` to catch dependency issues.
-- Use `clean_build` when changing group structure.
+- "Create an Addressables group for character prefabs and add the hero prefab."
+- "Analyze Addressables issues and then build content."
+- "Run a clean Addressables build after reorganizing groups."
+
+## Common Issues
+
+- The wrong group or address is targeted: list groups first and verify the entry path.
+- Builds fail after structural changes: run `analyze` and prefer `clean_build`.
+- `fix_issues` can be broad: inspect the analysis result before applying it in a risky project.
+- Generic asset problems should go through `unity-asset-management`, not this skill.

--- a/.claude-plugin/plugins/unity-cli/skills/unity-addressables/references/addressables-build-loop.md
+++ b/.claude-plugin/plugins/unity-cli/skills/unity-addressables/references/addressables-build-loop.md
@@ -1,0 +1,21 @@
+# Addressables Build Loop
+
+## Recommended Order
+
+1. List or inspect current groups.
+2. Apply group and entry changes.
+3. Run `addressables_analyze`.
+4. Review whether `fix_issues` is appropriate.
+5. Build content.
+6. Use `clean_build` after large structural changes.
+
+## Risk Notes
+
+- Group moves can change downstream bundle layout.
+- `fix_issues` may alter more than one group or entry.
+- Clean builds are slower but safer after major reorganization.
+
+## Handoff Boundary
+
+- Use `unity-asset-management` for general asset dependency questions outside Addressables.
+- Use this skill only when the workflow is clearly about Addressables content or build steps.

--- a/.claude-plugin/plugins/unity-cli/skills/unity-asset-management/SKILL.md
+++ b/.claude-plugin/plugins/unity-cli/skills/unity-asset-management/SKILL.md
@@ -1,12 +1,35 @@
 ---
 name: unity-asset-management
-description: Manage Unity assets, materials, import settings, and asset dependencies using unity-cli.
+description: Manage Unity assets and import metadata with unity-cli. Use when the user asks to refresh the Asset Database, inspect asset info, create or modify materials, update import settings, or analyze asset dependencies before moving or deleting files. Do not use for Addressables-specific workflows or scene object edits.
 allowed-tools: Bash, Read, Grep, Glob
+metadata:
+  author: akiojin
+  version: 0.2.0
+  category: assets
 ---
 
 # Asset & Material Management
 
-Manage the Unity Asset Database, create/modify materials, and control import settings.
+Manage the Unity Asset Database, create or modify materials, and control import settings.
+Read `references/asset-safety.md` when the task involves dependency analysis, import changes, or material updates that may affect many assets.
+
+## Use When
+
+- The user wants to inspect, refresh, move, or otherwise manage project assets.
+- The user wants to create or update materials.
+- The user needs import settings or dependency analysis before file changes.
+
+## Do Not Use When
+
+- The task is specifically about Addressables groups and content builds.
+- The request is about scene object or prefab editing rather than asset files.
+
+## Recommended Flow
+
+1. Inspect the target asset or material before changing it.
+2. Run dependency analysis before deleting, moving, or changing shared assets.
+3. Apply import or material changes with the narrowest possible payload.
+4. Refresh the Asset Database if files changed outside the editor.
 
 ## Commands
 
@@ -27,7 +50,15 @@ unity-cli raw manage_asset_import_settings --json '{"action":"modify","assetPath
 unity-cli raw analyze_asset_dependencies --json '{"action":"get_dependencies","assetPath":"Assets/Prefabs/Player.prefab","recursive":true}'
 ```
 
-## Tips
+## Examples
 
-- Run `refresh_assets` after external file changes.
-- Use `analyze_asset_dependencies` to audit references before deleting assets.
+- "Refresh the asset database and inspect `Assets/Textures/hero.png`."
+- "Create a material for the player and tint it red."
+- "Check which assets depend on `Player.prefab` before I move it."
+
+## Common Issues
+
+- Asset changes made outside Unity are not visible: run `refresh_assets`.
+- Import changes affect more files than expected: inspect the asset first and keep the payload focused.
+- Deleting or moving assets is risky: use `analyze_asset_dependencies` before the mutation.
+- Addressables content issues belong in `unity-addressables`, not this skill.

--- a/.claude-plugin/plugins/unity-cli/skills/unity-asset-management/references/asset-safety.md
+++ b/.claude-plugin/plugins/unity-cli/skills/unity-asset-management/references/asset-safety.md
@@ -1,0 +1,19 @@
+# Asset Safety
+
+## Inspection First
+
+- Read asset info before changing import settings.
+- Run dependency analysis before moving or deleting shared assets.
+- Refresh the Asset Database after external file operations.
+
+## Material Updates
+
+- Create a new material when the user wants an isolated asset.
+- Modify an existing material only when shared usage is understood.
+- Keep material property payloads focused on the fields that actually change.
+
+## Import Settings
+
+- Treat import settings as project-wide behavior for that asset path.
+- Change only the relevant keys in the `settings` object.
+- Re-check the asset after a large import adjustment if the workflow depends on the new metadata.

--- a/.claude-plugin/plugins/unity-cli/skills/unity-cli-usage/SKILL.md
+++ b/.claude-plugin/plugins/unity-cli/skills/unity-cli-usage/SKILL.md
@@ -1,16 +1,39 @@
 ---
 name: unity-cli-usage
-description: Practical usage guide for the Rust-based unity-cli command set, including raw command fallback and instance switching.
+description: Use unity-cli as the default interface for Unity Editor automation and local code tools. Use when the user asks how to verify the CLI, connect to Unity, switch active instances, choose between typed commands and raw tools, or troubleshoot unity-cli setup. Do not use once a more specific scene, asset, code, or testing skill clearly matches the task.
 allowed-tools: Bash, Read, Grep, Glob
+metadata:
+  author: akiojin
+  version: 0.2.0
+  category: foundation
 ---
 
-# unity-cli Usage (Claude Code)
+# unity-cli Usage
 
 Use `unity-cli` as the primary Unity automation interface.
+Read `references/runtime-checklist.md` when installation mode, instance selection, or CI environment details matter.
 
-## Bootstrap (Required)
+## Use When
 
-Before running any Unity command, ensure `unity-cli` is available:
+- The user asks how to connect Claude Code to Unity through `unity-cli`.
+- The user needs help with `system ping`, `instances list`, `instances set-active`, or `--output json`.
+- The user asks whether to use a typed subcommand or `raw`.
+- The task is blocked on CLI setup, host/port selection, or connection troubleshooting.
+
+## Do Not Use When
+
+- A more specific Unity workflow skill already covers the requested task.
+- The user only wants to inspect or edit project files without using `unity-cli`.
+
+## Recommended Flow
+
+1. Verify whether `unity-cli` is available globally or must be run with `cargo run --`.
+2. Confirm the target Unity instance with `system ping` or `instances list`.
+3. Prefer typed subcommands such as `system`, `scene`, or `instances` when available.
+4. Fall back to `raw` only when there is no typed command for the needed tool.
+5. Use `--output json` for chained automation or when another tool will consume the result.
+
+## Bootstrap
 
 ```bash
 if ! command -v unity-cli >/dev/null 2>&1; then
@@ -37,7 +60,7 @@ unity-cli --version
 2. Use `raw` for the rest of Unity command types.
 3. Use `--output json` when chaining automation steps.
 
-## Examples
+## Commands
 
 ```bash
 unity-cli system ping
@@ -47,8 +70,15 @@ unity-cli instances list --ports 6400,6401
 unity-cli instances set-active localhost:6401
 ```
 
-## Safety Notes
+## Examples
 
-- If `instances set-active` fails with `unreachable`, run `instances list` and pick an `up` target.
-- Keep payloads as valid JSON objects.
-- Prefer explicit host/port in CI (`UNITY_CLI_HOST`, `UNITY_CLI_PORT`).
+- "Check whether `unity-cli` can reach my Unity Editor."
+- "Switch to the Unity instance running on port 6401."
+- "Tell me whether this workflow should use `scene create` or a raw tool call."
+
+## Common Issues
+
+- `unity-cli` not found: use `cargo run -- <args>` from the repo root or install the release binary.
+- `instances set-active` returns `unreachable`: run `instances list` and select a target with `up` status.
+- CI or remote runs target the wrong editor: set `UNITY_CLI_HOST` and `UNITY_CLI_PORT` explicitly.
+- Raw payloads fail: make sure `--json` receives a valid JSON object, not shell-expanded fragments.

--- a/.claude-plugin/plugins/unity-cli/skills/unity-cli-usage/references/runtime-checklist.md
+++ b/.claude-plugin/plugins/unity-cli/skills/unity-cli-usage/references/runtime-checklist.md
@@ -1,0 +1,25 @@
+# Runtime Checklist
+
+## Binary Selection
+
+- Prefer an installed `unity-cli` binary when it exists on `PATH`.
+- If the repo is the current workspace and no global binary is installed, use `cargo run -- <args>`.
+- Verify the binary with `unity-cli --version` before debugging higher-level workflows.
+
+## Instance Selection
+
+- Use `unity-cli system ping` when a single active target is expected.
+- Use `unity-cli instances list` when multiple editors may be running.
+- Use `unity-cli instances set-active <host:port>` only after confirming the target is `up`.
+
+## Command Routing
+
+- Prefer typed subcommands for stable workflows such as `system`, `scene`, and `instances`.
+- Use `raw` when only the low-level tool exists or you need an exact tool payload.
+- Use `--output json` when another tool or script will consume the result.
+
+## CI Notes
+
+- Set `UNITY_CLI_HOST` and `UNITY_CLI_PORT` explicitly in CI.
+- Keep JSON payloads quoted as a single shell argument.
+- If connectivity fails in CI, report the resolved host and port before retrying.

--- a/.claude-plugin/plugins/unity-cli/skills/unity-csharp-edit/SKILL.md
+++ b/.claude-plugin/plugins/unity-cli/skills/unity-csharp-edit/SKILL.md
@@ -1,12 +1,36 @@
 ---
 name: unity-csharp-edit
-description: Edit, create, rename, and refactor C# code in Unity projects using unity-cli.
+description: Edit Unity C# code with unity-cli and LSP-backed write tools. Use when the user asks to rename symbols, replace method bodies, insert or remove members, create classes, or refactor scripts after inspecting code context. Do not use for read-only inspection; use the C# navigation skill when no code change is required.
 allowed-tools: Bash, Read, Grep, Glob
+metadata:
+  author: akiojin
+  version: 0.2.0
+  category: code
 ---
 
 # C# Change Workflow
 
 Plan and verify C# changes with unity-cli local tools, then apply file edits in the repository.
+Read `references/lsp-write-safety.md` when you need preview-first edits, `namePath` guidance, or post-change verification steps.
+
+## Use When
+
+- The user wants to edit, create, rename, or refactor Unity C# scripts.
+- The task can be expressed through symbol-aware LSP operations or `create_class`.
+- The change should be validated with compilation state after it is applied.
+
+## Do Not Use When
+
+- The user only wants to inspect or explain existing code.
+- The change is primarily about scenes, prefabs, or Unity object state rather than source files.
+
+## Recommended Flow
+
+1. Build or refresh the index, then inspect the target symbol with `read`, `get_symbols`, or `find_symbol`.
+2. Preview the edit with `apply: false` whenever the tool supports it.
+3. Apply one targeted mutation at a time with the appropriate LSP write tool or `create_class`.
+4. Refresh the index for changed paths and check `get_compilation_state`.
+5. If the edit is risky or touches multiple symbols, explain the expected scope before applying it.
 
 ## Commands
 
@@ -50,18 +74,23 @@ unity-cli raw get_compilation_state --json '{}'
 ## LSP Write Tools
 
 All LSP write tools accept `apply` (boolean, default false):
-- `apply: false` — preview mode, returns diff without modifying files
-- `apply: true` — applies changes to disk
+- `apply: false` - preview mode, returns diff without modifying files
+- `apply: true` - applies changes to disk
 
 The `namePath` parameter navigates nested symbols with `/` separators:
-- `"Player"` — top-level class
-- `"Player/Jump"` — method Jump inside class Player
-- `"Player/Config/MaxSpeed"` — field in nested type
+- `"Player"` - top-level class
+- `"Player/Jump"` - method Jump inside class Player
+- `"Player/Config/MaxSpeed"` - field in nested type
 
-## Tips
+## Examples
 
-- Run `update_index` after edits for accurate symbol lookup.
-- Use `get_compilation_state` to check for errors after changes.
-- Preview changes with `apply: false` before applying.
-- Use `validate_text_edits` to check C# syntax before writing files.
-- `create_class` creates the file and directory structure atomically.
+- "Rename `Player/Jump` to `Leap` everywhere it is safe to do so."
+- "Insert a new method after `Player/Jump` and then check compilation."
+- "Create a new `EnemyAI` MonoBehaviour under `Assets/Scripts/AI`."
+
+## Common Issues
+
+- `namePath` does not match the target: run `get_symbols` first and use the exact nested path.
+- A removal may break references: inspect `find_refs` before calling `remove_symbol`.
+- The edited file fails to compile: run `get_compilation_state` and fix the reported diagnostics before continuing.
+- Preview-first edits are safer; use `apply: false` unless the change is trivial and well-scoped.

--- a/.claude-plugin/plugins/unity-cli/skills/unity-csharp-edit/references/lsp-write-safety.md
+++ b/.claude-plugin/plugins/unity-cli/skills/unity-csharp-edit/references/lsp-write-safety.md
@@ -1,0 +1,24 @@
+# LSP Write Safety
+
+## Preview First
+
+- Use `apply: false` for `rename_symbol`, `replace_symbol_body`, `insert_before_symbol`, `insert_after_symbol`, and `remove_symbol` when the scope is not trivial.
+- Describe the intended edit in terms of symbol names before applying it.
+
+## Symbol Targeting
+
+- Use `get_symbols` to confirm the exact `namePath`.
+- Keep `namePath` slash-separated from outer type to inner member.
+- Use `find_refs` before destructive renames or removals.
+
+## Validation
+
+1. Apply the smallest viable edit.
+2. Run `update_index` for touched paths.
+3. Check `get_compilation_state`.
+4. Report diagnostics before attempting unrelated follow-up changes.
+
+## Class Creation
+
+- Use `create_class` for new files instead of hand-writing boilerplate when possible.
+- Use `validate_text_edits` when constructing larger manual replacements.

--- a/.claude-plugin/plugins/unity-cli/skills/unity-csharp-navigate/SKILL.md
+++ b/.claude-plugin/plugins/unity-cli/skills/unity-csharp-navigate/SKILL.md
@@ -1,12 +1,36 @@
 ---
 name: unity-csharp-navigate
-description: Explore C# code in Unity projects — read files, search symbols, find references, and list packages.
+description: Explore Unity C# code without modifying files. Use when the user asks to read scripts, search text, find symbols, trace references, inspect namespaces or packages, or understand where a class, method, or field is used. Do not use for code edits, renames, or refactors; use the editing skill for those.
 allowed-tools: Bash, Read, Grep, Glob
+metadata:
+  author: akiojin
+  version: 0.2.0
+  category: code
 ---
 
 # C# Code Exploration
 
-Navigate and search C# source using the unity-cli local tools (LSP-backed).
+Navigate and search C# source using the unity-cli local tools.
+Read `references/code-search-playbook.md` when you need indexing strategy, path narrowing, or reference tracing guidance.
+
+## Use When
+
+- The user wants to inspect a script or understand existing C# behavior.
+- The user asks where a symbol is defined or referenced.
+- The user wants to search packages or source trees before making a change.
+
+## Do Not Use When
+
+- The user wants to modify code or create new C# files.
+- The task depends on Unity scene state rather than source files.
+
+## Recommended Flow
+
+1. Build or refresh the index before symbol-heavy queries.
+2. Start with `read` or `search` to anchor on the right file or path.
+3. Use `get_symbols`, `find_symbol`, and `find_refs` once the target identifier is clear.
+4. Narrow the search path or page size if the result set is large.
+5. Use `list_packages` when the question might involve packages rather than project sources.
 
 ## Commands
 
@@ -30,8 +54,15 @@ unity-cli raw build_index --json '{}'
 unity-cli raw list_packages --json '{}'
 ```
 
-## Tips
+## Examples
 
-- These commands run locally (no Unity Editor connection required).
-- Build the index first with `unity-cli raw build_index` for fast symbol lookups.
-- Use `path` in `search` to narrow scope.
+- "Read `PlayerController.cs` and explain how jumping works."
+- "Find every reference to `Health` in project scripts."
+- "List installed packages and check whether Input System is present."
+
+## Common Issues
+
+- Symbol lookups return nothing: run `unity-cli raw build_index --json '{}'` or `update_index` for the changed path.
+- Results are too broad: use `path` in `search` or `pageSize` in `find_refs`.
+- The user needs an actual code change: hand off to `unity-csharp-edit` after gathering context.
+- These tools work locally; a Unity Editor connection is not required.

--- a/.claude-plugin/plugins/unity-cli/skills/unity-csharp-navigate/references/code-search-playbook.md
+++ b/.claude-plugin/plugins/unity-cli/skills/unity-csharp-navigate/references/code-search-playbook.md
@@ -1,0 +1,20 @@
+# Code Search Playbook
+
+## Index Strategy
+
+- Run `build_index` before the first symbol-heavy query in a session.
+- Run `update_index` after file edits or when the user points at a recently changed path.
+- Keep searches path-scoped whenever the target area is known.
+
+## Query Order
+
+1. Use `read` for exact-file inspection.
+2. Use `search` when you know a text pattern but not the symbol container.
+3. Use `get_symbols` to inspect a file's structure.
+4. Use `find_symbol` and `find_refs` when the symbol name is known.
+
+## Large Results
+
+- Add `pageSize` to `find_refs` for heavily used symbols.
+- Narrow `search` with `path` to avoid noisy hits.
+- If packages may own the behavior, check `list_packages` instead of searching only `Assets/`.

--- a/.claude-plugin/plugins/unity-cli/skills/unity-editor-tools/SKILL.md
+++ b/.claude-plugin/plugins/unity-cli/skills/unity-editor-tools/SKILL.md
@@ -1,12 +1,36 @@
 ---
 name: unity-editor-tools
-description: Unity Editor utilities -- ping, project settings, profiler, console, menu items, windows, and selection.
+description: Inspect and control Unity Editor state with unity-cli. Use when the user asks to ping the editor, read console output, inspect or update project settings, run menu items, inspect windows or selection, manage packages, or capture profiler data. Do not use for scene creation, asset editing, or C# refactors that have their own dedicated skills.
 allowed-tools: Bash, Read, Grep, Glob
+metadata:
+  author: akiojin
+  version: 0.2.0
+  category: editor
 ---
 
 # Editor Utilities & Profiler
 
-General editor operations, diagnostics, profiling, and project settings.
+Use this skill for editor-wide diagnostics and operations.
+Read `references/editor-ops-checklist.md` when you need a safer sequence for settings, package, or profiler changes.
+
+## Use When
+
+- The user asks for editor health checks, console logs, or profiler data.
+- The user wants to inspect or change project settings.
+- The user wants to run a menu item, inspect windows, or manipulate current selection.
+- The user wants package manager or registry operations from the editor side.
+
+## Do Not Use When
+
+- The task is primarily about a specific scene, prefab, asset, or script workflow.
+- The user only needs local source inspection with no Unity Editor interaction.
+
+## Recommended Flow
+
+1. Start with `unity-cli system ping` and `get_editor_state` so later actions run against a known-good editor.
+2. Read state before mutating it: console before clearing, settings before updating, profiler status before starting or stopping.
+3. Apply one editor-wide change at a time and verify the result immediately.
+4. When project settings or packages change, capture the before/after state in the response.
 
 ## Connection & Info
 
@@ -60,8 +84,15 @@ unity-cli raw package_manager --json '{"action":"install","packageId":"com.unity
 unity-cli raw registry_config --json '{"action":"list"}'
 ```
 
-## Tips
+## Examples
 
-- Use `system ping` as a health check before automation.
-- Use `tool list` to discover available raw commands.
-- Query profiler metrics with `listAvailable` before requesting specific metrics.
+- "Show me the latest Unity console errors."
+- "Update the company name in Project Settings."
+- "Start the profiler, let it record briefly, then stop and report the status."
+
+## Common Issues
+
+- `system ping` fails: the Unity Editor bridge is not reachable, so stop before running settings or profiler operations.
+- Console output is too noisy: add filters such as `count`, `filterText`, or `logTypes` before clearing anything.
+- `update_project_settings` is rejected: include `"confirmChanges": true` and send only the sections that need to change.
+- Profiler results are empty: query `profiler_status` first and use `profiler_get_metrics --json '{"listAvailable":true}'` before requesting specific metrics.

--- a/.claude-plugin/plugins/unity-cli/skills/unity-editor-tools/references/editor-ops-checklist.md
+++ b/.claude-plugin/plugins/unity-cli/skills/unity-editor-tools/references/editor-ops-checklist.md
@@ -1,0 +1,26 @@
+# Editor Ops Checklist
+
+## Safe Order
+
+1. Ping the editor and capture `get_editor_state`.
+2. Read the current state before changing it.
+3. Apply one editor-wide change at a time.
+4. Re-read the relevant state and summarize the delta.
+
+## Settings Changes
+
+- Use `get_project_settings` first so the response can mention the current value.
+- Send the narrowest `update_project_settings` payload possible.
+- Include `"confirmChanges": true` for mutating settings updates.
+
+## Console and Profiler
+
+- Read the console before clearing it.
+- Check `profiler_status` before starting or stopping capture.
+- Query `profiler_get_metrics --json '{"listAvailable":true}'` before requesting named metrics.
+
+## Package Operations
+
+- List installed packages before installing or removing one.
+- Treat registry changes as project-wide mutations and call them out explicitly.
+- If package changes are part of a larger workflow, mention any restart or reimport implications.

--- a/.claude-plugin/plugins/unity-cli/skills/unity-gameobject-edit/SKILL.md
+++ b/.claude-plugin/plugins/unity-cli/skills/unity-gameobject-edit/SKILL.md
@@ -1,12 +1,35 @@
 ---
 name: unity-gameobject-edit
-description: Edit GameObjects, modify or remove components, manage tags and layers in Unity.
+description: Edit existing GameObjects and components in Unity with unity-cli. Use when the user asks to rename objects, move or deactivate them, change component fields, add or remove tags and layers, or delete objects or components in an existing scene. Do not use for new scene bootstrapping or prefab edit mode; those have dedicated skills.
 allowed-tools: Bash, Read, Grep, Glob
+metadata:
+  author: akiojin
+  version: 0.2.0
+  category: scenes
 ---
 
 # GameObject & Component Editing
 
 Modify existing GameObjects and their components.
+Read `references/component-edit-safety.md` when the task involves destructive edits, nested field paths, or tag/layer changes.
+
+## Use When
+
+- The user wants to change an existing object's properties or hierarchy.
+- The user wants to inspect, modify, or remove components on an existing object.
+- The user needs tag or layer management in the current project.
+
+## Do Not Use When
+
+- The task is to create a brand new scene layout from scratch.
+- The task is specifically about prefab asset editing rather than scene objects.
+
+## Recommended Flow
+
+1. Identify the exact `gameObjectPath` and current components before changing anything.
+2. Apply one mutation at a time with `modify_gameobject`, `modify_component`, or field-level edits.
+3. Use destructive commands like `delete_gameobject` or `remove_component` only after confirming scope.
+4. Save the scene after destructive or bulk updates.
 
 ## Commands
 
@@ -27,7 +50,15 @@ unity-cli raw manage_tags --json '{"action":"add","tagName":"Enemy"}'
 unity-cli raw manage_layers --json '{"action":"get"}'
 ```
 
-## Tips
+## Examples
 
-- `set_component_field` supports dot-separated `fieldPath` for nested fields.
-- Save the scene after destructive edits.
+- "Deactivate `/Player` and rename it to `Hero`."
+- "Change the Rigidbody mass on `/Player` and move it to a new position."
+- "Remove the old collider from `/Obstacle` after checking its components."
+
+## Common Issues
+
+- `gameObjectPath` is wrong: inspect the hierarchy first and use the full path.
+- `set_component_field` fails: use dot-separated `fieldPath` values and verify the target component exists.
+- Destructive edits removed too much: prefer listing components or inspecting the object before delete operations.
+- Save the scene after destructive edits so changes do not vanish on reload.

--- a/.claude-plugin/plugins/unity-cli/skills/unity-gameobject-edit/references/component-edit-safety.md
+++ b/.claude-plugin/plugins/unity-cli/skills/unity-gameobject-edit/references/component-edit-safety.md
@@ -1,0 +1,19 @@
+# Component Edit Safety
+
+## Before Mutating
+
+- Confirm the full `gameObjectPath`.
+- List or inspect current components when the target component type may be duplicated.
+- Call out destructive edits before applying them.
+
+## Field Updates
+
+- `set_component_field` uses dot-separated `fieldPath` values for nested fields.
+- Prefer field-level updates when a full `modify_component` payload would be noisy.
+- Keep values explicit for vectors, colors, and nested structs.
+
+## Destructive Changes
+
+- Remove or delete one target at a time unless the user asked for a bulk cleanup.
+- Save the scene after destructive changes.
+- If the user wants to change the prefab asset instead of the scene instance, switch to `unity-prefab-workflow`.

--- a/.claude-plugin/plugins/unity-cli/skills/unity-input-system/SKILL.md
+++ b/.claude-plugin/plugins/unity-cli/skills/unity-input-system/SKILL.md
@@ -1,12 +1,35 @@
 ---
 name: unity-input-system
-description: Configure Unity Input System action maps, actions, bindings, and control schemes using unity-cli.
+description: Configure Unity Input System assets with unity-cli. Use when the user asks to create or remove action maps, add or remove actions and bindings, set up composite bindings, inspect input action assets, or manage control schemes. Do not use for runtime input simulation during tests; use the PlayMode testing skill for that workflow.
 allowed-tools: Bash, Read, Grep, Glob
+metadata:
+  author: akiojin
+  version: 0.2.0
+  category: input
 ---
 
 # Input System Configuration
 
 Manage Input Action Assets: action maps, actions, bindings, and control schemes.
+Read `references/input-actions-playbook.md` when you need sequencing for action maps, composite bindings, or control scheme design.
+
+## Use When
+
+- The user wants to author or update `.inputactions` assets.
+- The task is about action maps, actions, bindings, or control schemes.
+- The user wants to inspect the structure of an input actions asset before modifying it.
+
+## Do Not Use When
+
+- The user wants to simulate keyboard, mouse, gamepad, or touch input during runtime tests.
+- The task is only to verify whether the Input System package is installed.
+
+## Recommended Flow
+
+1. Decide which asset path and action map the change belongs to.
+2. Create or inspect the action map before adding actions or bindings.
+3. Add actions first, then bindings, then control schemes or composites.
+4. Run `analyze_input_actions_asset` after non-trivial edits to catch structural issues.
 
 ## Action Maps
 
@@ -39,7 +62,15 @@ unity-cli raw get_input_actions_state --json '{}'
 unity-cli raw manage_control_schemes --json '{"assetPath":"Assets/Input/Controls.inputactions","operation":"add","schemeName":"KeyboardMouse","devices":["Keyboard","Mouse"]}'
 ```
 
-## Tips
+## Examples
 
-- `actionType` values: `Button`, `Value`, `PassThrough`.
-- Use `analyze_input_actions_asset` to audit before builds.
+- "Create a `Gameplay` action map with `Jump` and keyboard bindings."
+- "Add a 2D movement composite to the `Move` action."
+- "Inspect this input actions asset and tell me whether it is missing control schemes."
+
+## Common Issues
+
+- Bindings are added before the action exists: create the action first.
+- Composite bindings are malformed: verify the `bindings` object contains all required parts.
+- Runtime testing is needed after the asset change: switch to `unity-playmode-testing`.
+- `actionType` values should be `Button`, `Value`, or `PassThrough`.

--- a/.claude-plugin/plugins/unity-cli/skills/unity-input-system/references/input-actions-playbook.md
+++ b/.claude-plugin/plugins/unity-cli/skills/unity-input-system/references/input-actions-playbook.md
@@ -1,0 +1,22 @@
+# Input Actions Playbook
+
+## Authoring Order
+
+1. Identify the target `.inputactions` asset.
+2. Create or select the action map.
+3. Add actions.
+4. Add bindings or composites.
+5. Add control schemes if needed.
+6. Analyze the asset.
+
+## Binding Guidance
+
+- Create the action before adding its bindings.
+- Use composite bindings when a single action needs structured directional input.
+- Remove obsolete bindings before replacing them wholesale.
+
+## Validation
+
+- Run `analyze_input_actions_asset` after structural changes.
+- Separate asset authoring from runtime validation.
+- Use `unity-playmode-testing` for actual input simulation after the asset change lands.

--- a/.claude-plugin/plugins/unity-cli/skills/unity-playmode-testing/SKILL.md
+++ b/.claude-plugin/plugins/unity-cli/skills/unity-playmode-testing/SKILL.md
@@ -1,12 +1,36 @@
 ---
 name: unity-playmode-testing
-description: Control Unity PlayMode, run tests, simulate input, capture screenshots and video using unity-cli.
+description: Drive Unity runtime verification with unity-cli. Use when the user asks to enter or exit Play Mode, run EditMode or PlayMode tests, simulate keyboard, mouse, gamepad, or touch input, capture screenshots or video, or inspect current test status. Do not use for authoring input action assets; use the Input System skill for that.
 allowed-tools: Bash, Read, Grep, Glob
+metadata:
+  author: akiojin
+  version: 0.2.0
+  category: testing
 ---
 
 # PlayMode, Testing & Input Simulation
 
-Control play/pause/stop, run tests, simulate input devices, and capture media.
+Control Play Mode, run tests, simulate input devices, and capture media.
+Read `references/playmode-test-loop.md` when you need a clean execution loop for entering Play Mode, sending input, waiting for results, and capturing evidence.
+
+## Use When
+
+- The user wants to run EditMode or PlayMode tests.
+- The task requires runtime input simulation.
+- The user wants screenshots or video from the current game or editor state.
+- The user wants to inspect current test progress or runtime state.
+
+## Do Not Use When
+
+- The task is about editing input action assets rather than runtime behavior.
+- The request is purely about static scene or code inspection.
+
+## Recommended Flow
+
+1. Confirm editor state before entering Play Mode or running tests.
+2. Enter Play Mode or start tests, then wait until the runtime is ready before sending input.
+3. Capture screenshots or short video only after the target state is visible.
+4. Stop Play Mode or recording cleanly and report the final status.
 
 ## Play Control
 
@@ -46,8 +70,15 @@ unity-cli raw run_tests --json '{"testMode":"EditMode","filter":"PlayerTests"}'
 unity-cli raw get_test_status --json '{}'
 ```
 
-## Tips
+## Examples
 
-- Wait for Play Mode before sending input-heavy sequences.
-- Prefer `maxDurationSec` on `capture_video_start` for auto-stop runs.
-- `testMode` values: `EditMode`, `PlayMode`, `All`.
+- "Run PlayMode tests for the player flow and report the result."
+- "Enter Play Mode, press space, and capture a screenshot."
+- "Record a 5 second gameplay clip and stop automatically."
+
+## Common Issues
+
+- Input is ignored: wait until Play Mode is fully active before sending input.
+- Long recordings never stop: prefer `maxDurationSec` for unattended captures.
+- Test scope is too broad: use `filter` or a single `testMode` before running the suite.
+- `testMode` values are `EditMode`, `PlayMode`, or `All`.

--- a/.claude-plugin/plugins/unity-cli/skills/unity-playmode-testing/references/playmode-test-loop.md
+++ b/.claude-plugin/plugins/unity-cli/skills/unity-playmode-testing/references/playmode-test-loop.md
@@ -1,0 +1,21 @@
+# PlayMode Test Loop
+
+## Default Runtime Loop
+
+1. Check editor state.
+2. Enter Play Mode or start the test run.
+3. Wait until the runtime is ready.
+4. Send input or capture evidence.
+5. Read status and stop cleanly.
+
+## Input Timing
+
+- Avoid input bursts before Play Mode is active.
+- Prefer `create_input_sequence` for short repeated actions.
+- Re-check state after major interactions when the UI or scene should react.
+
+## Evidence Capture
+
+- Use screenshots for single-state proof.
+- Use short video clips for motion or timing-sensitive proof.
+- Prefer `maxDurationSec` on video capture for unattended runs.

--- a/.claude-plugin/plugins/unity-cli/skills/unity-prefab-workflow/SKILL.md
+++ b/.claude-plugin/plugins/unity-cli/skills/unity-prefab-workflow/SKILL.md
@@ -1,12 +1,28 @@
 ---
 name: unity-prefab-workflow
-description: Create, edit, instantiate, and manage Unity Prefabs using unity-cli.
+description: Manage Unity prefab assets with unity-cli. Use when the user asks to create a prefab from a scene object, open a prefab in edit mode, save prefab changes, instantiate a prefab into a scene, or update prefab asset properties. Do not use for general scene object editing outside prefab workflows.
 allowed-tools: Bash, Read, Grep, Glob
+metadata:
+  author: akiojin
+  version: 0.2.0
+  category: prefabs
 ---
 
 # Prefab Lifecycle
 
-Create, open, edit, and instantiate Prefabs.
+Create, open, edit, and instantiate prefabs.
+Read `references/prefab-edit-mode.md` when you need a safe sequence for edit mode, scene handoff, or instantiation checks.
+
+## Use When
+
+- The user wants to create or update a prefab asset.
+- The task requires entering prefab edit mode and saving changes back to the asset.
+- The user wants to instantiate prefab assets into a scene with specific transforms.
+
+## Do Not Use When
+
+- The request is about editing ordinary scene objects with no prefab asset involved.
+- The task is only about creating a scene from scratch.
 
 ## Commands
 
@@ -33,7 +49,15 @@ unity-cli raw modify_prefab --json '{"prefabPath":"Assets/Prefabs/Player.prefab"
 3. `save_prefab` to persist
 4. `exit_prefab_mode` to return to scene
 
-## Tips
+## Examples
 
-- Always `exit_prefab_mode` before switching scenes.
-- Use `instantiate_prefab` with `position`/`rotation` for placement.
+- "Create a prefab from `/Player` and save it under `Assets/Prefabs/Player.prefab`."
+- "Open an existing prefab, change it, save it, and exit prefab mode."
+- "Instantiate a prefab at the origin for a test scene."
+
+## Common Issues
+
+- Changes do not persist: call `save_prefab` before exiting edit mode.
+- The editor remains stuck in prefab mode: explicitly call `exit_prefab_mode` before switching scenes.
+- The user actually wants to edit a scene instance, not the prefab asset: switch to `unity-gameobject-edit`.
+- Use explicit `position` or `rotation` values during instantiation when placement matters.

--- a/.claude-plugin/plugins/unity-cli/skills/unity-prefab-workflow/references/prefab-edit-mode.md
+++ b/.claude-plugin/plugins/unity-cli/skills/unity-prefab-workflow/references/prefab-edit-mode.md
@@ -1,0 +1,20 @@
+# Prefab Edit Mode
+
+## Safe Sequence
+
+1. Create or open the prefab asset.
+2. Make the scoped changes in prefab edit mode.
+3. Save the prefab.
+4. Exit prefab mode before switching contexts.
+
+## Scene vs Asset
+
+- `modify_prefab` targets the asset.
+- `instantiate_prefab` creates a scene instance.
+- If the user wants to tweak only one placed instance, use `unity-gameobject-edit` instead.
+
+## Common Pitfalls
+
+- Unsaved prefab edits are lost on exit.
+- Remaining in prefab mode can confuse later scene operations.
+- Instantiation placement should use explicit transform values when the exact spawn position matters.

--- a/.claude-plugin/plugins/unity-cli/skills/unity-scene-create/SKILL.md
+++ b/.claude-plugin/plugins/unity-cli/skills/unity-scene-create/SKILL.md
@@ -1,12 +1,28 @@
 ---
 name: unity-scene-create
-description: Create and set up Unity scenes, GameObjects, and components using unity-cli.
+description: Create and bootstrap Unity scenes with unity-cli. Use when the user asks to create a new scene, load or save a scene, add starter GameObjects, or attach components while setting up a level or test scene. Do not use for editing existing objects in place or working inside prefab edit mode; use the dedicated editing or prefab skills for those cases.
 allowed-tools: Bash, Read, Grep, Glob
+metadata:
+  author: akiojin
+  version: 0.2.0
+  category: scenes
 ---
 
 # Scene & GameObject Creation
 
 Create scenes, GameObjects, and attach components via `unity-cli`.
+Read `references/scene-bootstrap-patterns.md` when you need a safer scene setup order or a reminder of common starter patterns.
+
+## Use When
+
+- The user wants to create a new scene from scratch.
+- The user asks to add initial objects and components while bootstrapping a scene.
+- The user needs help loading, saving, or organizing a scene setup workflow.
+
+## Do Not Use When
+
+- The request is mainly about mutating existing objects in an already-prepared scene.
+- The work is focused on prefab editing rather than scene authoring.
 
 ## Workflow
 
@@ -33,8 +49,15 @@ unity-cli raw add_component --json '{"gameObjectPath":"/Player","componentType":
 unity-cli raw add_component --json '{"gameObjectPath":"/Player","componentType":"BoxCollider"}'
 ```
 
-## Tips
+## Examples
 
-- Use `primitiveType` values: `cube`, `sphere`, `capsule`, `cylinder`, `plane`, `quad`.
-- Always save the scene after bulk changes.
-- Chain with `--output json` for automation.
+- "Create a new gameplay scene and add a `Player` object with physics components."
+- "Load `Assets/Scenes/TestScene.unity`, add a camera rig, then save it."
+- "Bootstrap a simple empty scene for UI testing."
+
+## Common Issues
+
+- The scene is created but not persisted: call `save_scene` after bulk changes.
+- Objects end up in the wrong place: set `parentPath` explicitly during creation.
+- Primitive setup is inconsistent: use supported `primitiveType` values such as `cube`, `sphere`, `capsule`, `cylinder`, `plane`, or `quad`.
+- If the task turns into modifying existing objects rather than creating them, switch to `unity-gameobject-edit`.

--- a/.claude-plugin/plugins/unity-cli/skills/unity-scene-create/references/scene-bootstrap-patterns.md
+++ b/.claude-plugin/plugins/unity-cli/skills/unity-scene-create/references/scene-bootstrap-patterns.md
@@ -1,0 +1,20 @@
+# Scene Bootstrap Patterns
+
+## Default Flow
+
+1. Create or load the scene.
+2. Add top-level GameObjects.
+3. Add required components.
+4. Save the scene.
+
+## Starter Scene Tips
+
+- Create parent objects early when the final hierarchy matters.
+- Use primitives only for quick placeholders or test fixtures.
+- Save after each major batch when the scene is being built incrementally.
+
+## Handoff Boundaries
+
+- If the user starts tuning existing object properties, switch to `unity-gameobject-edit`.
+- If the work becomes prefab-centric, switch to `unity-prefab-workflow`.
+- When the scene is intended for runtime verification, follow up with `unity-playmode-testing`.

--- a/.claude-plugin/plugins/unity-cli/skills/unity-scene-inspect/SKILL.md
+++ b/.claude-plugin/plugins/unity-cli/skills/unity-scene-inspect/SKILL.md
@@ -1,12 +1,35 @@
 ---
 name: unity-scene-inspect
-description: Analyze Unity scene hierarchy, find GameObjects, inspect components, and query animator state.
+description: Inspect Unity scenes without mutating them. Use when the user asks to analyze scene hierarchy, list scenes, find GameObjects by name or component, inspect component values, review object references, or query animator state. Do not use for creating scenes or editing GameObjects; use the creation or editing skills for those workflows.
 allowed-tools: Bash, Read, Grep, Glob
+metadata:
+  author: akiojin
+  version: 0.2.0
+  category: scenes
 ---
 
 # Scene Analysis & Navigation
 
 Inspect scene hierarchy, find objects, and read component data.
+Read `references/scene-inspection-playbook.md` when the scene is large, object names are duplicated, or you need a step-by-step inspection flow.
+
+## Use When
+
+- The user wants to inspect the current scene before making changes.
+- The user asks where a GameObject, component, or animator state lives.
+- The user wants a hierarchy summary, scene inventory, or reference analysis.
+
+## Do Not Use When
+
+- The task is to create new scenes or modify existing objects.
+- The user only needs source-code analysis with no scene context.
+
+## Recommended Flow
+
+1. Start with `get_scene_info`, `list_scenes`, or `get_hierarchy` to understand the current scope.
+2. Locate candidate objects with `find_gameobject` or `find_by_component`.
+3. Inspect the chosen target with `get_gameobject_details`, `get_component_values`, or animator queries.
+4. Use `analyze_scene_contents` for broad audits or when inactive objects matter.
 
 ## Commands
 
@@ -33,7 +56,15 @@ unity-cli raw get_animator_state --json '{"gameObjectName":"Player"}'
 unity-cli raw get_animator_runtime_info --json '{"gameObjectName":"Player"}'
 ```
 
-## Tips
+## Examples
 
-- Use `nameOnly` in `get_hierarchy` for large scenes.
-- Pipe JSON output through `jq` for filtering.
+- "Show me the current scene hierarchy and find the player camera."
+- "Inspect the `Transform` values on `Player`."
+- "Tell me which animator state the character is currently in."
+
+## Common Issues
+
+- The scene is large: start with `get_hierarchy --json '{"nameOnly":true}'` and then narrow down.
+- Multiple objects share the same name: use details and references to disambiguate before reporting results.
+- Inactive objects are missing from audits: use `analyze_scene_contents --json '{"includeInactive":true}'`.
+- These tools are read-only; switch to the creation or editing skill before making mutations.

--- a/.claude-plugin/plugins/unity-cli/skills/unity-scene-inspect/references/scene-inspection-playbook.md
+++ b/.claude-plugin/plugins/unity-cli/skills/unity-scene-inspect/references/scene-inspection-playbook.md
@@ -1,0 +1,20 @@
+# Scene Inspection Playbook
+
+## Recommended Order
+
+1. Start with `get_scene_info` or `list_scenes`.
+2. Use `get_hierarchy` to build a quick mental model.
+3. Narrow with `find_gameobject` or `find_by_component`.
+4. Inspect details only after the target object is clear.
+
+## Large Scene Tactics
+
+- Use `get_hierarchy --json '{"nameOnly":true}'` first.
+- Include inactive objects in audit-style queries.
+- Prefer targeted component reads over large hierarchy dumps when the user asks about a single object.
+
+## Ambiguous Objects
+
+- Duplicate names are common; confirm by reading details or references.
+- Report the full object path or distinguishing component data when names collide.
+- Use animator queries only after the correct object is identified.

--- a/.claude-plugin/plugins/unity-cli/skills/unity-ui-automation/SKILL.md
+++ b/.claude-plugin/plugins/unity-cli/skills/unity-ui-automation/SKILL.md
@@ -1,12 +1,35 @@
 ---
 name: unity-ui-automation
-description: Find, inspect, and interact with Unity UI elements for automated testing using unity-cli.
+description: Automate Unity UI inspection and interaction with unity-cli. Use when the user asks to find UI elements by name or type, inspect button or input state, click UI elements, set UI values, or run short UI interaction sequences during testing. Do not use for scene creation or general PlayMode control when UI-specific targeting is not needed.
 allowed-tools: Bash, Read, Grep, Glob
+metadata:
+  author: akiojin
+  version: 0.2.0
+  category: ui
 ---
 
 # UI Element Automation
 
 Find, inspect, and interact with UI elements (uGUI / UI Toolkit).
+Read `references/ui-test-flow.md` when you need a safer locate-inspect-interact sequence for UI testing.
+
+## Use When
+
+- The user wants to locate UI elements by name or type.
+- The task requires inspecting UI state before or after interaction.
+- The user wants to click UI elements, set values, or run a short UI input sequence.
+
+## Do Not Use When
+
+- The task is general PlayMode setup with no UI targeting requirement.
+- The request is about editing UI prefabs or scene hierarchy rather than testing interactions.
+
+## Recommended Flow
+
+1. Find the target UI element with `namePattern` or `elementType`.
+2. Inspect its current state before acting, especially for visibility and interactability.
+3. Perform one interaction at a time and re-check state when the sequence matters.
+4. Combine with PlayMode control only when the UI depends on runtime state.
 
 ## Commands
 
@@ -24,8 +47,15 @@ unity-cli raw set_ui_element_value --json '{"elementPath":"/Canvas/NameInput","v
 unity-cli raw simulate_ui_input --json '{"inputSequence":[{"type":"setvalue","params":{"elementPath":"/Canvas/Slider","value":"0.75"}}],"waitBetween":50}'
 ```
 
-## Tips
+## Examples
 
-- Use `namePattern` and `elementType` to narrow results.
-- `get_ui_element_state` returns visibility, interactability, and current value.
-- Combine with PlayMode testing for end-to-end UI tests.
+- "Find the start button and click it."
+- "Read the current value of `/Canvas/NameInput` and then set it to `Player1`."
+- "Run a short slider interaction sequence in the active UI."
+
+## Common Issues
+
+- The element is not found: narrow with `namePattern` or `elementType`, and include inactive elements when needed.
+- The click has no effect: inspect `get_ui_element_state` first to verify visibility and interactability.
+- A longer runtime test is needed: combine with `unity-playmode-testing` for Play Mode control.
+- Use `simulate_ui_input` for compact repeated interactions rather than many one-off commands.

--- a/.claude-plugin/plugins/unity-cli/skills/unity-ui-automation/references/ui-test-flow.md
+++ b/.claude-plugin/plugins/unity-cli/skills/unity-ui-automation/references/ui-test-flow.md
@@ -1,0 +1,19 @@
+# UI Test Flow
+
+## Locate, Inspect, Interact
+
+1. Locate the element with `find_ui_elements`.
+2. Inspect it with `get_ui_element_state`.
+3. Interact with the narrowest command possible.
+4. Re-read state if the next step depends on the UI reaction.
+
+## Practical Tips
+
+- Use `namePattern` when the hierarchy is stable.
+- Use `elementType` when names vary but the control kind is known.
+- Include inactive elements only when the user is explicitly debugging hidden UI.
+
+## When to Combine Skills
+
+- Use `unity-playmode-testing` when the UI must be exercised during Play Mode transitions.
+- Use scene inspection or editing skills only if the task shifts from testing to authoring the UI structure.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ separately using one of the manual options below.
 ### Codex Skills
 
 When using this repository with Codex, skills are available via `.codex/skills/` (symlinks to the plugin source).
-No additional setup is required — just clone the repository.
+No additional setup is required - just clone the repository.
 
 ### Manual Install
 
@@ -82,7 +82,9 @@ unity-cli cli install
 `unityd` and `lspd` automatically refresh their managed `unity-cli` / C# LSP binaries on daemon startup.
 The managed copies live under `UNITY_CLI_TOOLS_ROOT` (or the OS default tools directory) and are updated without an interactive confirmation prompt.
 
-## Skills (13)
+## Skills (14)
+
+These skills are written as workflow guides, not just command catalogs. They are designed to trigger from natural Unity requests such as "create a test scene", "trace references to this MonoBehaviour", or "run PlayMode tests and capture a screenshot".
 
 | Category | Skills |
 | --- | --- |
@@ -92,6 +94,7 @@ The managed copies live under `UNITY_CLI_TOOLS_ROOT` (or the OS default tools di
 | Code | `unity-csharp-navigate`, `unity-csharp-edit` |
 | Runtime & Testing | `unity-playmode-testing`, `unity-input-system`, `unity-ui-automation` |
 | Editor | `unity-editor-tools` |
+| Maintenance | `gh-skills-sync` |
 
 ## Quick Examples
 


### PR DESCRIPTION
## Summary

- Rewrite the 14 unity-cli skill definitions to add explicit triggers, scoped workflows, and troubleshooting guidance so Claude can route Unity tasks more reliably.
- Add per-skill reference playbooks under `references/` so reusable safety and execution details stay out of the trigger-focused `SKILL.md` bodies.
- Update the README and plugin metadata to describe the skills as workflow-oriented automation so the published docs match the revised skill behavior.

## Changes

- `.claude-plugin/plugins/unity-cli/skills/*/SKILL.md`: expanded frontmatter descriptions, added `metadata.version`, and standardized `Use When`, `Do Not Use When`, `Recommended Flow`, `Examples`, and `Common Issues` sections.
- `.claude-plugin/plugins/unity-cli/skills/*/references/*.md`: added 14 reference playbooks covering runtime checks, editor operations, code search/edit safety, scene and prefab workflows, asset/input/test loops, UI automation, and gh skill sync behavior.
- `README.md`, `.claude-plugin/plugins/unity-cli/plugin.json`, `.claude-plugin/marketplace.json`: updated public descriptions and the skill inventory to match the workflow-guide positioning.

## Testing

- [x] `./scripts/skill-eval/static-skill-contract-check.sh --report /tmp/skill-static-report.json --json` - exits with `"passed": true` and `"errorsCount": 0`.
- [x] `python3 - <<"PY" ... PY` - parsed every skill frontmatter as YAML and confirmed all referenced `references/*.md` files exist.
- [x] `git diff --check` - reports no whitespace or merge-marker issues.

## Related Issues / Links

- https://resources.anthropic.com/hubfs/The-Complete-Guide-to-Building-Skill-for-Claude.pdf
- None

## Checklist

- [ ] Tests added/updated - N/A: no automated test files changed; validation is covered by the existing static skill checks.
- [ ] Lint/format passed (`cargo clippy`, `cargo fmt`, `svelte-check`) - N/A: this PR only changes skill/docs metadata and does not touch Rust or Svelte sources.
- [x] Documentation updated (if user-facing change)
- [ ] Migration/backfill plan included (if schema/data change) - N/A: no schema or data migration is involved.
- [x] CHANGELOG impact considered (breaking change flagged in commit)

## Context

- This PR aligns the unity-cli skill pack with the published Anthropic skills guidance by tightening trigger metadata, adopting progressive disclosure with per-skill references, and making each skill describe a concrete workflow instead of a flat command list.
