### PR TITLE
fix(lsp): remove stale switch expression in SymbolKindCode delegate

### DIFF
--- a/lsp/Program.cs
+++ b/lsp/Program.cs
@@ -1449,7 +1449,7 @@ sealed class LspServer
     private static string? ContainerName(string namePath)
         => LspPathUtilities.ContainerName(namePath);
 
-    private static int SymbolKindCode(string kind) => kind switch
+    private static int SymbolKindCode(string kind)
         => LspCodeIndexModels.SymbolKindCode(kind);
 
     private List<UnityCli.Lsp.Core.CodeIndexEntry> CollectEntries(SyntaxNode root, string relativePath) =>


### PR DESCRIPTION
## Summary

Release v0.5.0 のLSPビルド失敗を修正するホットフィックス。

## Changes

- `lsp/Program.cs:1452` の不正な `kind switch =>` 構文を除去（Server.Core への委譲リファクタ時の残骸）

## Context

PR #116 マージ後のリリースワークフローで全LSPプラットフォームのビルドが失敗。
このマージ後にタグ `v0.5.0` を再作成してリリースを再実行する。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

このプルリクエストはコード内部の改善が含まれていますが、ユーザーに対する機能的な変更はありません。

* **Refactor**
  * 内部のコード構造を改善し、コード保守性を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->