### PR TITLE
feat(reference): extract_token_at_cursor を C# lexer 化（Phase 4-C / Refs #191）

### DIFF
--- a/src/reference/mod.rs
+++ b/src/reference/mod.rs
@@ -341,6 +341,9 @@ fn extract_token_at_cursor(content: &str, line: u32, column: u32) -> Option<Stri
     if col_idx >= chars.len() || !is_ident_char(chars[col_idx]) {
         return None;
     }
+    if is_cursor_in_comment_or_string(&chars, col_idx) {
+        return None;
+    }
     let mut start = col_idx;
     while start > 0 && is_ident_char(chars[start - 1]) {
         start -= 1;
@@ -350,6 +353,29 @@ fn extract_token_at_cursor(content: &str, line: u32, column: u32) -> Option<Stri
         end += 1;
     }
     Some(chars[start..end].iter().collect())
+}
+
+fn is_cursor_in_comment_or_string(chars: &[char], col_idx: usize) -> bool {
+    let mut in_string = false;
+    let mut i = 0;
+    while i < col_idx {
+        let c = chars[i];
+        if in_string {
+            if c == '\\' && i + 1 < chars.len() {
+                i += 2;
+                continue;
+            }
+            if c == '"' {
+                in_string = false;
+            }
+        } else if c == '"' {
+            in_string = true;
+        } else if c == '/' && i + 1 < chars.len() && chars[i + 1] == '/' {
+            return true;
+        }
+        i += 1;
+    }
+    in_string
 }
 
 fn is_ident_char(c: char) -> bool {
@@ -1177,5 +1203,39 @@ mod tests {
         assert_eq!(extract_token_at_cursor(content, 1, 4), None);
         // Out-of-range line returns None
         assert_eq!(extract_token_at_cursor(content, 99, 1), None);
+    }
+
+    #[test]
+    fn extract_token_at_cursor_skips_line_comment() {
+        let content = "var x = 1; // Animator was here\n";
+        // 'A' of Animator inside comment is at column 15
+        assert_eq!(extract_token_at_cursor(content, 1, 15), None);
+    }
+
+    #[test]
+    fn extract_token_at_cursor_skips_string_literal() {
+        let content = "var s = \"Animator\"; var y = 1;\n";
+        // 'A' of Animator inside string is at column 10
+        assert_eq!(extract_token_at_cursor(content, 1, 10), None);
+    }
+
+    #[test]
+    fn extract_token_at_cursor_returns_ident_after_closed_string() {
+        let content = "var s = \"abc\"; Animator a;\n";
+        // 'A' of Animator after closed string is at column 16
+        assert_eq!(
+            extract_token_at_cursor(content, 1, 16),
+            Some("Animator".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_token_at_cursor_handles_escaped_quote_in_string() {
+        let content = "var s = \"a\\\"b\"; Animator a;\n";
+        // After the escaped string closes at \"; the cursor sits on the A of Animator (column 17)
+        assert_eq!(
+            extract_token_at_cursor(content, 1, 17),
+            Some("Animator".to_string())
+        );
     }
 }


### PR DESCRIPTION
## Summary

- SPEC #191 (Phase 4 umbrella) のサブタスク **Phase 4-C** として、`extract_token_at_cursor` をミニ C# lexer 化する。
- Phase 3 (SPEC #188) で MVP land した regex ベースの token extractor は line comment (`// ...`) や string literal (`"..."`) 内の identifier も拾ってしまう問題があった。`resolve-symbol-at` の偽陽性候補を抑制する。

## Changes

- `src/reference/mod.rs::is_cursor_in_comment_or_string` を新設。カーソル位置までの 1 行を scan し、`// line comment` 内と `"..." string literal` 内かを判定する。`\"` エスケープは string を閉じない扱い。
- `extract_token_at_cursor` がカーソル位置の class を判定し、comment 内 / string 内なら `None` を返すように改良。
- 新規 RED テスト 4 件:
  - `extract_token_at_cursor_skips_line_comment`
  - `extract_token_at_cursor_skips_string_literal`
  - `extract_token_at_cursor_returns_ident_after_closed_string`
  - `extract_token_at_cursor_handles_escaped_quote_in_string`

## Testing

- [x] `cargo fmt -- --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test --bin unity-cli` — **386 passed / 0 failed**
- [x] `cargo llvm-cov --all-targets --summary-only -- --test-threads=1` — TOTAL line coverage **91.03%**
- [x] `unity-cli skills lint --severity error` — 15 skills / 0 violations

## Closing Issues

- None (umbrella SPEC #191 は完了せず、サブタスク追加でも生き続けるため `Refs` のみ)

## Related Issues / Links

- Umbrella: #191
- Phase 1-3: #185 / #187 / #188 (MERGED)
- Phase 4-B: PR #193 (MERGED)

## Checklist

- [x] Tests added/updated (4 件)
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`, `unity-cli skills lint`)
- [x] Documentation updated — none required (内部実装の改善で公開 API 変更なし)
- [ ] Migration/backfill plan included — Not applicable: 入出力の構造は不変、`tokenName` が `null` で返るケースが拡張されるだけ
- [x] CHANGELOG impact considered — minor bump per Conventional Commits (`feat`)

## Context

`resolve-symbol-at` は project file の cursor 位置から reference cache の候補を返す薄い wrapper。Phase 3 MVP では正規表現ベースの identifier 抽出だったため、LLM が cursor をコメントや文字列リテラル内に置いたときに偽の `tokenName` を返してしまい、`candidates` も虚しく埋まっていた。本 PR で line comment と string literal の 2 ケースを除外し、cursor が code 領域にあるときだけ token を抽出する。

## Out of Scope

umbrella SPEC #191 で継続管理する範囲:

- block comment `/* ... */` の multi-line 判定。現状は 1 行内のみ。
- char literal `'...'` や interpolated string `$"..."`、verbatim string `@"..."` の特例。
- preprocessor directive `#if` / `#endif` の中の cursor。
- Phase 4-A (member-level シンボル抽出) / Phase 4-D (`reference fetch` の zip fallback) / Phase 4-E (vector embedding) は umbrella の Tasks として未着手。

## Notes

- block comment の multi-line 判定はファイル全体スキャンが必要で、本 PR では意図的にスコープアウト。LLM のカーソルが block comment 内に来るケースは line comment より稀との判断。
