### PR TITLE
chore(deps): bump rustls-webpki from 0.103.10 to 0.103.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -825,9 +825,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
## Summary

- Bumps `rustls-webpki` from `0.103.10` to `0.103.13` (security update).
- `rustls-webpki` is a transitive dependency via `ureq → rustls → rustls-webpki`, so only `Cargo.lock` changes are needed.

## Background

Dependabot opened the original bump as #179 targeting `main` directly, which the Main PR Policy blocks. Since the dependabot config (`.github/dependabot.yml`) targets `develop`, #179 was closed and the change is reapplied here against `develop`.

## Test plan

- [x] `cargo build --all-targets`
- [ ] CI green (Rust Format & Lint / Tests / Coverage / LSP / Skill Contract Lint / Markdown & Commitlint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
