### PR TITLE
feat(reference): reference fetch に zip fallback を追加（Phase 4-D / Refs #191）

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -74,6 +85,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -87,6 +107,15 @@ checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
@@ -95,10 +124,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "bzip2"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49ecfb22d906f800d4fe833b6282cf4dc1c298f5057ca0b5445e5c209735ca47"
+dependencies = [
+ "bzip2-sys",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.13+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
 
 [[package]]
 name = "cc"
@@ -107,6 +167,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -115,6 +177,16 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common 0.1.7",
+ "inout",
+]
 
 [[package]]
 name = "clap"
@@ -169,6 +241,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
+name = "constant_time_eq"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
+
+[[package]]
 name = "cookie"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -199,6 +277,15 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
@@ -207,12 +294,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
 ]
 
 [[package]]
@@ -225,6 +343,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "deflate64"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac6b926516df9c60bfa16e107b21086399f8285a44ca9711344b9e553c5146e2"
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -234,14 +358,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+ "subtle",
+]
+
+[[package]]
 name = "digest"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.12.0",
  "const-oid",
- "crypto-common",
+ "crypto-common 0.2.1",
 ]
 
 [[package]]
@@ -339,6 +485,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -347,6 +503,20 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -382,6 +552,15 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest 0.10.7",
+]
 
 [[package]]
 name = "http"
@@ -529,6 +708,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -539,6 +727,27 @@ name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "lazy_static"
@@ -601,6 +810,27 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lzma-rs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "297e814c836ae64db86b36cf2a557ba54368d03f6afcd7d947c266692f71115e"
+dependencies = [
+ "byteorder",
+ "crc",
+]
+
+[[package]]
+name = "lzma-sys"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
 
 [[package]]
 name = "matchers"
@@ -672,6 +902,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest 0.10.7",
+ "hmac",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -682,6 +922,12 @@ name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "potential_utf"
@@ -835,6 +1081,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
 name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -914,14 +1166,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "sha2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.3.0",
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -1215,6 +1478,7 @@ dependencies = [
  "tracing-subscriber",
  "ureq",
  "walkdir",
+ "zip",
 ]
 
 [[package]]
@@ -1329,6 +1593,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.121"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.121"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.121"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.121"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
+dependencies = [
+ "unicode-ident",
 ]
 
 [[package]]
@@ -1566,6 +1875,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
+name = "xz2"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
+dependencies = [
+ "lzma-sys",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1614,6 +1932,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zerotrie"
@@ -1649,7 +1981,77 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+dependencies = [
+ "aes",
+ "arbitrary",
+ "bzip2",
+ "constant_time_eq",
+ "crc32fast",
+ "crossbeam-utils",
+ "deflate64",
+ "displaydoc",
+ "flate2",
+ "getrandom 0.3.4",
+ "hmac",
+ "indexmap",
+ "lzma-rs",
+ "memchr",
+ "pbkdf2",
+ "sha1",
+ "thiserror",
+ "time",
+ "xz2",
+ "zeroize",
+ "zopfli",
+ "zstd",
+]
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ sha2 = "0.11"
 ureq = { version = "3.3", features = ["json"] }
 serde_yml = "0.0.12"
 similar = "2"
+zip = "2"
 
 [dev-dependencies]
 tempfile = "3.27"

--- a/src/reference/fetcher.rs
+++ b/src/reference/fetcher.rs
@@ -1,4 +1,6 @@
-use std::path::Path;
+use std::fs;
+use std::io::{Cursor, Read};
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use anyhow::{anyhow, Context, Result};
@@ -62,7 +64,14 @@ pub fn run_clone(
     accept_license: bool,
 ) -> Result<()> {
     require_license_accepted(accept_license)?;
-    ensure_git_available()?;
+    if ensure_git_available().is_ok() {
+        return run_clone_via_git(url, branch, dest, depth);
+    }
+    // git binary unavailable: fall back to archive download.
+    fetch_via_zip(branch, dest)
+}
+
+fn run_clone_via_git(url: &str, branch: &str, dest: &Path, depth: u32) -> Result<()> {
     let mut cmd = Command::new("git");
     if let Some(token) = github_token() {
         cmd.arg("-c")
@@ -79,6 +88,91 @@ pub fn run_clone(
         return Err(anyhow!("git clone exited with status {status}"));
     }
     Ok(())
+}
+
+/// Branch -> GitHub archive zip URL.
+pub fn archive_url_for_branch(branch: &str) -> String {
+    format!(
+        "https://github.com/Unity-Technologies/UnityCsReference/archive/refs/heads/{branch}.zip"
+    )
+}
+
+pub fn fetch_via_zip(branch: &str, dest: &Path) -> Result<()> {
+    let url = archive_url_for_branch(branch);
+    let agent = ureq::Agent::new_with_defaults();
+    let mut request = agent.get(&url);
+    if let Some(token) = github_token() {
+        request = request.header("Authorization", format!("token {token}"));
+    }
+    let response = request
+        .call()
+        .with_context(|| format!("failed to GET {url}"))?;
+    let mut body = response.into_body();
+    let mut buffer = Vec::new();
+    body.as_reader()
+        .read_to_end(&mut buffer)
+        .with_context(|| format!("failed to read archive body for {url}"))?;
+    extract_zip_to(&buffer, dest)
+}
+
+pub fn extract_zip_to(archive_bytes: &[u8], dest: &Path) -> Result<()> {
+    fs::create_dir_all(dest)
+        .with_context(|| format!("failed to create destination {}", dest.display()))?;
+    let cursor = Cursor::new(archive_bytes);
+    let mut archive =
+        zip::ZipArchive::new(cursor).context("failed to open zip archive from buffer")?;
+    let prefix = detect_top_level_prefix(&mut archive)?;
+    for i in 0..archive.len() {
+        let mut file = archive
+            .by_index(i)
+            .with_context(|| format!("failed to read zip entry {i}"))?;
+        let raw_name = file.name().to_string();
+        let stripped = match strip_prefix(&raw_name, &prefix) {
+            Some(s) if !s.is_empty() => s.to_string(),
+            _ => continue,
+        };
+        if stripped.contains("..") {
+            return Err(anyhow!(
+                "zip entry escapes destination via parent segments: {raw_name}"
+            ));
+        }
+        let target_path: PathBuf = dest.join(&stripped);
+        if raw_name.ends_with('/') {
+            fs::create_dir_all(&target_path)
+                .with_context(|| format!("failed to create directory {}", target_path.display()))?;
+            continue;
+        }
+        if let Some(parent) = target_path.parent() {
+            fs::create_dir_all(parent)
+                .with_context(|| format!("failed to create parent {}", parent.display()))?;
+        }
+        let mut out = fs::File::create(&target_path)
+            .with_context(|| format!("failed to open {} for writing", target_path.display()))?;
+        std::io::copy(&mut file, &mut out)
+            .with_context(|| format!("failed to write {}", target_path.display()))?;
+    }
+    Ok(())
+}
+
+fn detect_top_level_prefix(archive: &mut zip::ZipArchive<Cursor<&[u8]>>) -> Result<String> {
+    if archive.is_empty() {
+        return Err(anyhow!("zip archive is empty"));
+    }
+    let first = archive.by_index(0).context("zip archive has no entries")?;
+    let name = first.name();
+    if let Some(idx) = name.find('/') {
+        Ok(name[..=idx].to_string())
+    } else {
+        Ok(String::new())
+    }
+}
+
+fn strip_prefix<'a>(name: &'a str, prefix: &str) -> Option<&'a str> {
+    if prefix.is_empty() {
+        Some(name)
+    } else {
+        name.strip_prefix(prefix)
+    }
 }
 
 #[cfg(test)]
@@ -198,5 +292,68 @@ mod tests {
         let dest = PathBuf::from("/tmp/unity-cli-reference-clone-license-guard");
         let err = run_clone(UNITY_CS_REFERENCE_URL, "2023.2/staging", &dest, 1, false).unwrap_err();
         assert!(format!("{err:#}").contains("Unity Companion License"));
+    }
+
+    #[test]
+    fn archive_url_uses_unity_cs_reference_org() {
+        let url = archive_url_for_branch("2023.2/staging");
+        assert!(url.starts_with(
+            "https://github.com/Unity-Technologies/UnityCsReference/archive/refs/heads/"
+        ));
+        assert!(url.ends_with("/2023.2/staging.zip"));
+    }
+
+    fn build_sample_zip() -> Vec<u8> {
+        use std::io::Write;
+        use zip::write::SimpleFileOptions;
+        let mut buf = Vec::new();
+        {
+            let mut writer = zip::ZipWriter::new(std::io::Cursor::new(&mut buf));
+            let options =
+                SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored);
+            writer
+                .start_file("UnityCsReference-fixture/Editor/Foo.cs", options)
+                .unwrap();
+            writer.write_all(b"public class Foo {}\n").unwrap();
+            writer
+                .start_file("UnityCsReference-fixture/Runtime/Bar/Bar.cs", options)
+                .unwrap();
+            writer.write_all(b"public class Bar {}\n").unwrap();
+            writer.finish().unwrap();
+        }
+        buf
+    }
+
+    #[test]
+    fn extract_zip_to_strips_top_level_prefix_and_writes_files() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let buf = build_sample_zip();
+        extract_zip_to(&buf, tmp.path()).unwrap();
+        let foo = tmp.path().join("Editor/Foo.cs");
+        let bar = tmp.path().join("Runtime/Bar/Bar.cs");
+        assert!(foo.exists(), "Editor/Foo.cs should exist");
+        assert!(bar.exists(), "Runtime/Bar/Bar.cs should exist");
+        let contents = std::fs::read_to_string(&foo).unwrap();
+        assert!(contents.contains("class Foo"));
+    }
+
+    #[test]
+    fn extract_zip_to_rejects_entries_with_parent_segments() {
+        use std::io::Write;
+        use zip::write::SimpleFileOptions;
+        let mut buf = Vec::new();
+        {
+            let mut writer = zip::ZipWriter::new(std::io::Cursor::new(&mut buf));
+            let options =
+                SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored);
+            writer
+                .start_file("UnityCsReference-fixture/../escape.cs", options)
+                .unwrap();
+            writer.write_all(b"bad").unwrap();
+            writer.finish().unwrap();
+        }
+        let tmp = tempfile::TempDir::new().unwrap();
+        let err = extract_zip_to(&buf, tmp.path()).unwrap_err();
+        assert!(format!("{err:#}").contains(".."));
     }
 }


### PR DESCRIPTION
## Summary

- SPEC #191 (Phase 4 umbrella) のサブタスク **Phase 4-D** として、`reference fetch` に GitHub archive 経由の zip fallback を追加する。
- これで `git` バイナリが PATH に無い CI runner / slim image でも UnityCsReference キャッシュを取得できる。

## Changes

- `Cargo.toml`: `zip = "2"` を `[dependencies]` に追加（default features で deflate 含む、圧縮済み GitHub archive を解凍可能）。
- `src/reference/fetcher.rs::run_clone`: `ensure_git_available()` が OK なら従来の `git clone`、Err なら `fetch_via_zip` に切り替える分岐を追加。
- 新規関数:
  - `archive_url_for_branch(branch)`: `https://github.com/Unity-Technologies/UnityCsReference/archive/refs/heads/<branch>.zip` を構築。
  - `fetch_via_zip(branch, dest)`: ureq でアーカイブを取得し、`GITHUB_TOKEN` / `GH_TOKEN` を透過注入。
  - `extract_zip_to(archive_bytes, dest)`: GitHub archive の top-level prefix (`UnityCsReference-<branch>/`) を strip して `dest` に展開。`..` を含む entry は安全のため reject。
  - `detect_top_level_prefix` / `strip_prefix`: helpers。
- 新規 RED テスト 3 件:
  - `archive_url_uses_unity_cs_reference_org`
  - `extract_zip_to_strips_top_level_prefix_and_writes_files` (ZipWriter で生成した buffer を使う)
  - `extract_zip_to_rejects_entries_with_parent_segments`

## Testing

- [x] `cargo fmt -- --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test --bin unity-cli` — **389 passed / 0 failed**
- [x] `cargo llvm-cov --all-targets --summary-only -- --test-threads=1` — TOTAL line coverage **90.88%**
- [x] `unity-cli skills lint --severity error` — 15 skills / 0 violations

## Closing Issues

- None (umbrella SPEC #191 は完了せず継続)

## Related Issues / Links

- Umbrella: #191
- Phase 1-3: #185 / #187 / #188 (MERGED)
- Phase 4-B: PR #193 (MERGED)
- Phase 4-C: PR #194 (MERGED)

## Checklist

- [x] Tests added/updated (3 件 + ZipWriter ベースの fixture helper)
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`, `unity-cli skills lint`)
- [x] Documentation updated — none required (`run_clone` の public API は不変)
- [ ] Migration/backfill plan included — Not applicable: zip fallback は git 不在時のみ動作。既存ユーザーには影響なし
- [x] CHANGELOG impact considered — minor bump per Conventional Commits (`feat`)

## Context

Phase 1 (SPEC #185) で `reference fetch` は `git clone --depth 1` 前提で実装し、Phase 1.5 として `zip` fallback を保留していた。本 PR はその保留分を land する。`git` バイナリ不在の CI runner や slim Docker image でも `unity-cli reference fetch` が動くようになる。

## Out of Scope

umbrella SPEC #191 で継続管理する範囲:

- ネットワーク経由の実 download integration test（CI flake になりやすいため、本 PR では ZipWriter で生成したローカル buffer での test のみ）
- GitHub API レート制限のリトライ・バックオフ
- Unix 権限ビット (chmod) の保持
- Phase 4-A (member-level シンボル抽出) / Phase 4-E (vector embedding) は未着手

## Notes

- `zip = "2"` の default features は bzip2 / lzma / zstd / aes-crypto / deflate を含むため、target サイズが多少増える。size sensitive な配布向けに後追いで feature を絞る検討余地あり。
- `fetch_via_zip` 内の `ureq::Agent::new_with_defaults` は既存 `src/core/managed_binaries.rs` の HTTP 利用に揃えた。リトライは未実装で、ネットワーク失敗時はエラーをそのまま伝播する。
