### PR TITLE
feat(reference): member-level シンボル抽出 MVP（Phase 4-A / Refs #191）

### DIFF
--- a/src/reference/index.rs
+++ b/src/reference/index.rs
@@ -58,6 +58,8 @@ impl Default for ReferenceSymbolIndex {
 pub fn extract_symbols_from_text(content: &str, rel_path: &str) -> Vec<ReferenceSymbolEntry> {
     static NAMESPACE_RE: OnceLock<Regex> = OnceLock::new();
     static TYPE_RE: OnceLock<Regex> = OnceLock::new();
+    static METHOD_RE: OnceLock<Regex> = OnceLock::new();
+    static PROPERTY_RE: OnceLock<Regex> = OnceLock::new();
     let ns_re = NAMESPACE_RE.get_or_init(|| {
         Regex::new(r"(?m)^\s*namespace\s+([A-Za-z_][A-Za-z0-9_.]*)")
             .expect("namespace regex compiles")
@@ -68,12 +70,25 @@ pub fn extract_symbols_from_text(content: &str, rel_path: &str) -> Vec<Reference
         )
         .expect("type regex compiles")
     });
+    let method_re = METHOD_RE.get_or_init(|| {
+        Regex::new(
+            r"(?m)^[ \t]*(?:\[[^\]]*\][ \t]*)*(?:public|internal|protected|private)[ \t]+(?:(?:static|virtual|override|abstract|sealed|partial|async|extern|new|readonly|unsafe)[ \t]+)*(?:[A-Za-z_][\w<>,\?\[\]\. \t]*?)[ \t]+([A-Za-z_][A-Za-z0-9_]*)[ \t]*\(",
+        )
+        .expect("method regex compiles")
+    });
+    let property_re = PROPERTY_RE.get_or_init(|| {
+        Regex::new(
+            r"(?m)^[ \t]*(?:\[[^\]]*\][ \t]*)*(?:public|internal|protected|private)[ \t]+(?:(?:static|virtual|override|abstract|sealed|partial|readonly)[ \t]+)*(?:[A-Za-z_][\w<>,\?\[\]\. \t]*?)[ \t]+([A-Za-z_][A-Za-z0-9_]*)[ \t]*\{[ \t]*(?:get|set)",
+        )
+        .expect("property regex compiles")
+    });
 
     let namespace = ns_re
         .captures(content)
         .and_then(|c| c.get(1).map(|m| m.as_str().to_string()));
 
     let mut symbols = Vec::new();
+    let mut consumed_spans: Vec<(usize, usize)> = Vec::new();
     for cap in type_re.captures_iter(content) {
         let kind = cap
             .get(1)
@@ -87,6 +102,7 @@ pub fn extract_symbols_from_text(content: &str, rel_path: &str) -> Vec<Reference
             continue;
         }
         let full = cap.get(0).expect("full match exists");
+        consumed_spans.push((full.start(), full.end()));
         let line = (content[..full.start()].matches('\n').count() as u32) + 1;
         let fqn = namespace.as_ref().map(|ns| format!("{ns}.{name}"));
         symbols.push(ReferenceSymbolEntry {
@@ -99,7 +115,60 @@ pub fn extract_symbols_from_text(content: &str, rel_path: &str) -> Vec<Reference
             fqn,
         });
     }
+    for cap in property_re.captures_iter(content) {
+        let name = cap
+            .get(1)
+            .map(|m| m.as_str().to_string())
+            .unwrap_or_default();
+        if name.is_empty() {
+            continue;
+        }
+        let full = cap.get(0).expect("full match exists");
+        if overlaps_consumed(full.start(), &consumed_spans) {
+            continue;
+        }
+        consumed_spans.push((full.start(), full.end()));
+        let line = (content[..full.start()].matches('\n').count() as u32) + 1;
+        let fqn = namespace.as_ref().map(|ns| format!("{ns}.{name}"));
+        symbols.push(ReferenceSymbolEntry {
+            path: rel_path.to_string(),
+            name,
+            kind: "property".to_string(),
+            line,
+            namespace: namespace.clone(),
+            container: None,
+            fqn,
+        });
+    }
+    for cap in method_re.captures_iter(content) {
+        let name = cap
+            .get(1)
+            .map(|m| m.as_str().to_string())
+            .unwrap_or_default();
+        if name.is_empty() {
+            continue;
+        }
+        let full = cap.get(0).expect("full match exists");
+        if overlaps_consumed(full.start(), &consumed_spans) {
+            continue;
+        }
+        let line = (content[..full.start()].matches('\n').count() as u32) + 1;
+        let fqn = namespace.as_ref().map(|ns| format!("{ns}.{name}"));
+        symbols.push(ReferenceSymbolEntry {
+            path: rel_path.to_string(),
+            name,
+            kind: "method".to_string(),
+            line,
+            namespace: namespace.clone(),
+            container: None,
+            fqn,
+        });
+    }
     symbols
+}
+
+fn overlaps_consumed(pos: usize, spans: &[(usize, usize)]) -> bool {
+    spans.iter().any(|(start, end)| pos >= *start && pos < *end)
 }
 
 pub fn file_signature(metadata: &fs::Metadata) -> String {
@@ -283,6 +352,49 @@ mod tests {
         assert!(symbols
             .iter()
             .any(|s| s.name == "Vec3" && s.kind == "struct"));
+    }
+
+    #[test]
+    fn extract_symbols_from_text_finds_methods() {
+        let text = "namespace UnityEngine {\n    public class Animator {\n        public void Play(string stateName) {}\n        public static int GetLayerCount() { return 0; }\n    }\n}\n";
+        let symbols = extract_symbols_from_text(text, "Runtime/Animator.cs");
+        let play = symbols
+            .iter()
+            .find(|s| s.name == "Play")
+            .expect("Play should be extracted");
+        assert_eq!(play.kind, "method");
+        assert_eq!(play.namespace.as_deref(), Some("UnityEngine"));
+        assert!(symbols
+            .iter()
+            .any(|s| s.name == "GetLayerCount" && s.kind == "method"));
+        assert!(symbols
+            .iter()
+            .any(|s| s.name == "Animator" && s.kind == "class"));
+    }
+
+    #[test]
+    fn extract_symbols_from_text_finds_property() {
+        let text =
+            "public class Foo {\n    public int Count { get; set; }\n    public string Name { get { return _name; } }\n}\n";
+        let symbols = extract_symbols_from_text(text, "Runtime/Foo.cs");
+        assert!(symbols
+            .iter()
+            .any(|s| s.name == "Count" && s.kind == "property"));
+        assert!(symbols
+            .iter()
+            .any(|s| s.name == "Name" && s.kind == "property"));
+        assert!(!symbols
+            .iter()
+            .any(|s| s.name == "Count" && s.kind == "method"));
+    }
+
+    #[test]
+    fn extract_symbols_from_text_does_not_double_capture_class_name() {
+        let text = "public class Bar {}\n";
+        let symbols = extract_symbols_from_text(text, "Runtime/Bar.cs");
+        let bar_entries: Vec<_> = symbols.iter().filter(|s| s.name == "Bar").collect();
+        assert_eq!(bar_entries.len(), 1);
+        assert_eq!(bar_entries[0].kind, "class");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- SPEC #191 (Phase 4 umbrella) のサブタスク **Phase 4-A** を最小 MVP として land する。
- Phase 2 の `reference find-symbol --kind method|property` が「`UnityEngine.Animator.Play`」のような典型シンボルを直接 lookup できるよう、`extract_symbols_from_text` を拡張する。

## Changes

- `src/reference/index.rs::extract_symbols_from_text` を 3 つの regex (`TYPE_RE` / `METHOD_RE` / `PROPERTY_RE`) で順に走査する形に書き換え。`overlaps_consumed` で既に capture 済みの span (type declaration) を skip し、`class Foo {}` の `Foo` が method として double-capture されないようにする。
- `METHOD_RE`: `public|internal|protected|private` + optional modifiers + return type + name + `(` の 1 行パターン。
- `PROPERTY_RE`: 同上だが `name { get|set` で終わる行を property として認識。
- 新規 RED テスト 3 件:
  - `extract_symbols_from_text_finds_methods`
  - `extract_symbols_from_text_finds_property`
  - `extract_symbols_from_text_does_not_double_capture_class_name`

## Testing

- [x] `cargo fmt -- --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test --bin unity-cli` — **392 passed / 0 failed**
- [x] `cargo llvm-cov --all-targets --summary-only -- --test-threads=1` — TOTAL line coverage **90.89%**
- [x] `unity-cli skills lint --severity error` — 15 skills / 0 violations

## Closing Issues

- None (umbrella SPEC #191 は完了せず継続)

## Related Issues / Links

- Umbrella: #191
- Phase 4-B / C / D: PR #193 / #194 / #196 (すべて MERGED)

## Checklist

- [x] Tests added/updated (3 件 + 既存 9 件が GREEN を維持)
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`, `unity-cli skills lint`)
- [x] Documentation updated — none required (`find-symbol` の公開 API は不変、`--kind method|property` を返せる対象が増えるだけ)
- [ ] Migration/backfill plan included — Not applicable: 既存 cache の `.unity-cli-index/symbols.json` は新コードで再 build される（`signature` 差分が検出され次第）
- [x] CHANGELOG impact considered — minor bump per Conventional Commits (`feat`)

## Context

Phase 2 (SPEC #187) では型のみを index に含めていたため、ユーザーが `find-symbol --name Play --kind method` を試しても空配列が返っていた。本 PR の MVP は単純な 1 行 regex で method / property を捕捉し、`reference find-symbol` の実用範囲を広げる。

## Out of Scope（umbrella #191 で継続管理）

- 多行シグネチャ（戻り値型と method 名が改行で分かれるケース）
- constructor / destructor（戻り値型を持たないため現 regex を通らない）
- field / event 抽出
- ジェネリック制約句 `where T : ...` の取り扱い
- record / record struct のような新しい型構文
- Phase 4-E (vector embedding) は未着手

regex MVP は偽陽性を含む可能性があるが、`--kind method` / `--kind property` フィルタで noise を抑えやすい。本格的な精度は Roslyn 経由解析の別 PR として後追い検討する余地がある。

## Notes

- 既存 type 抽出 (`TYPE_RE`) の挙動は変えていない。class / interface / struct / enum を見つけたファイルでは `consumed_spans` に span を入れ、その範囲を method / property regex の対象から除外する。これにより `public class Bar {}` の `Bar` が method として捕捉されない。
- index ファイル `.unity-cli-index/symbols.json` の version は維持。新コードで再 build される際、`signature` が変わっているファイルは新形式で書き直される。
