### PR TITLE
chore(release): v0.11.1

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -1,11 +1,11 @@
 ---
-description: developブランチでバージョン更新を行い、mainへのRelease PRを作成します（LLMベース）。
+description: develop または develop に fast-forward 可能な worktree からバージョン更新を行い、mainへのRelease PRを作成します（LLMベース）。
 tags: [project]
 ---
 
 # リリースコマンド（LLMベース）
 
-develop ブランチでバージョン更新・CHANGELOG更新を行い、main への Release PR を作成します。
+`origin/develop` に対してバージョン更新・CHANGELOG 更新の commit を land させ、main への Release PR を作成します。develop ブランチからも、develop に fast-forward 可能な gwt feature worktree からも実行可能です。
 
 ## フロー概要
 
@@ -17,7 +17,8 @@ develop (バージョン更新・CHANGELOG更新) → main (PR)
 
 ## 前提条件
 
-- `develop` ブランチにチェックアウトしていること
+- 現在の HEAD が `origin/develop` の ancestor であること (= fast-forward 可能、または既に origin/develop と一致)。gwt の feature worktree からでも実行可能
+- working tree が clean、または release に関係しないファイル編集を stash / commit / discard で除去済みであること
 - `git-cliff` がインストールされていること（`cargo install git-cliff`）
 - `gh` CLI が認証済み（`gh auth login`）
 - 前回リリースタグ以降にコミットがあること
@@ -26,21 +27,39 @@ develop (バージョン更新・CHANGELOG更新) → main (PR)
 
 以下の手順を **順番に** 実行してください。エラーが発生した場合は即座に中断し、エラーメッセージを日本語で表示してください。
 
-### 1. ブランチ確認
+### 1. fast-forward 可能性確認
+
+まず origin/develop を fetch し、現在の HEAD が ancestor かどうか確認：
 
 ```bash
-git rev-parse --abbrev-ref HEAD
+git fetch origin develop
+git merge-base --is-ancestor HEAD origin/develop
 ```
 
-**判定**: 結果が `develop` でなければ、以下のメッセージを表示して中断：
-> 「エラー: developブランチでのみ実行可能です。現在のブランチ: {ブランチ名}」
+**判定**:
+- ancestor check 成功 (exit 0): 続行（HEAD は origin/develop の祖先または同一）
+- 失敗 (exit 1): 以下のメッセージを表示して中断
+  > 「エラー: 現在の HEAD は origin/develop の ancestor ではありません。release は origin/develop に新 commit を land させる必要があるため、まず現 worktree の作業を develop に merge してから再実行してください。現在のブランチ: {ブランチ名}」
 
-### 2. リモート同期
+加えて、working tree の dirty 検知：
+
+```bash
+git status --porcelain
+```
+
+release に無関係な変更（`Cargo.toml` / `Cargo.lock` / `package.json` / `UnityCliBridge/Packages/unity-cli-bridge/package.json` / `CHANGELOG.md` 以外）が含まれていれば中断：
+> 「エラー: working tree に release と無関係な未 commit の変更があります。stash / commit / discard で除去してから再実行してください。」
+
+### 2. リモート同期と HEAD 前進
 
 ```bash
 git fetch origin main develop
-git pull origin develop
+git pull --ff-only origin develop
 ```
+
+`--ff-only` により、fast-forward できない場合は失敗して止まる（Step 1 の ancestor check で事前に確認済みのため通常は成功）。
+
+これは **branch 切替ではなく、現在の branch の HEAD を origin/develop tip まで前進させる操作** であり、AGENTS.md「branch / worktree を手動で作成・切替・削除しない」に抵触しない。HEAD が既に origin/develop と一致している場合は no-op で成功する。
 
 ### 3. リリース対象コミット確認
 
@@ -130,11 +149,13 @@ git commit -m "chore(release): v{NEW_VERSION}"
 ### 7. push
 
 ```bash
-git push origin develop
+git push origin HEAD:develop
 ```
 
+`HEAD:develop` の refspec push により、現 branch の名前に依存せず remote develop に release commit を land させる。develop ブランチ上で実行した場合も従来通り動作する（HEAD == develop の場合 `git push origin develop` と同義）。
+
 **失敗時**: 最大3回リトライ。それでも失敗した場合：
-> 「エラー: pushに失敗しました。ネットワーク接続を確認してください。」
+> 「エラー: push に失敗しました。他 agent / human が同時に develop を更新していないか、ネットワーク接続を確認してください。」
 
 ### 8. Closing Issue の収集
 
@@ -239,6 +260,17 @@ PR が main にマージされると、`.github/workflows/release.yml`（main pu
 4. GitHub Release を作成し、ビルド済みバイナリをアップロード
 
 **手動後処理**: 必要に応じて `cargo publish` を実行して crates.io に公開してください。
+
+## worktree からの実行について
+
+gwt で feature worktree（例: `work/YYYYMMDD-HHMM`）上にあるときも本コマンドは実行可能。具体的には:
+
+- Step 1 の `git merge-base --is-ancestor HEAD origin/develop` で、現 HEAD が origin/develop の ancestor であることを確認
+- Step 2 の `git pull --ff-only origin develop` で現 branch の HEAD を origin/develop tip まで前進させる
+- Step 7 の `git push origin HEAD:develop` の refspec push で remote develop に release commit を land させる
+- 結果、現 branch の名前は何であっても、操作は常に origin/develop を対象にする
+
+注意: 現 HEAD が origin/develop の ancestor でない場合（例: feature worktree が develop と独立した編集を持っている場合）は Step 1 で中断する。release 前に該当作業を develop に merge し終える必要がある。
 
 ## トラブルシューティング
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,8 +134,18 @@ jobs:
       - name: Install cross-compilation tools (Linux ARM64)
         if: matrix.target == 'aarch64-unknown-linux-gnu'
         run: |
+          sudo dpkg --add-architecture arm64
+          sudo sed -i 's|^deb http|deb [arch=amd64] http|' /etc/apt/sources.list || true
+          for codename in noble jammy; do
+            if grep -q "$codename" /etc/os-release; then
+              echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports $codename main restricted universe multiverse" | sudo tee /etc/apt/sources.list.d/arm64-ports.list
+              echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports $codename-updates main restricted universe multiverse" | sudo tee -a /etc/apt/sources.list.d/arm64-ports.list
+              echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports $codename-security main restricted universe multiverse" | sudo tee -a /etc/apt/sources.list.d/arm64-ports.list
+              break
+            fi
+          done
           sudo apt-get update
-          sudo apt-get install -y gcc-aarch64-linux-gnu
+          sudo apt-get install -y gcc-aarch64-linux-gnu libssl-dev:arm64 pkg-config
 
       - name: Cache cargo registry and build
         uses: actions/cache@v5
@@ -151,6 +161,9 @@ jobs:
         run: cargo build --release --target ${{ matrix.target }}
         env:
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: ${{ matrix.target == 'aarch64-unknown-linux-gnu' && 'aarch64-linux-gnu-gcc' || '' }}
+          PKG_CONFIG_ALLOW_CROSS: ${{ matrix.target == 'aarch64-unknown-linux-gnu' && '1' || '' }}
+          PKG_CONFIG_PATH: ${{ matrix.target == 'aarch64-unknown-linux-gnu' && '/usr/lib/aarch64-linux-gnu/pkgconfig' || '' }}
+          PKG_CONFIG_SYSROOT_DIR: ${{ matrix.target == 'aarch64-unknown-linux-gnu' && '/' || '' }}
 
       - name: Rename artifact (Unix)
         if: runner.os != 'Windows'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [0.11.1] - 2026-05-12
+
+### 🐛 Bug Fixes
+
+- *(release)* aarch64-unknown-linux-gnu cross-build で OpenSSL ARM64 ライブラリと pkg-config 環境変数を設定し、v0.11.0 で skip された GitHub Release バイナリ upload を復旧
+
 ## [0.11.0] - 2026-05-12
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3105,7 +3105,7 @@ checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
 name = "unity-cli"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unity-cli"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 description = "Rust CLI for Unity Editor automation over the Unity TCP protocol"
 readme = "README.md"

--- a/UnityCliBridge/Packages/unity-cli-bridge/package.json
+++ b/UnityCliBridge/Packages/unity-cli-bridge/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.akiojin.unity-cli-bridge",
   "displayName": "Unity CLI Bridge",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "unity": "6000.0",
   "description": "Unity Editor bridge package for unity-cli automation (screenshots, video capture, scene analysis, input automation).",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unity-cli-workspace",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "private": true,
   "packageManager": "pnpm@10.33.0",
   "description": "Development environment for unity-cli",

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -51,3 +51,10 @@
 - Mistake: ralph loop / autonomous 進行時に、umbrella SPEC があってもサブタスクごとに新 SPEC を生やす癖が出た。Phase 1-3 の「Phase ごとに 1 SPEC」パターンを引きずって過剰に細分化した。
 - Rule: umbrella SPEC が存在する Phase では、サブタスクで独立した SPEC を新設しない。実装は umbrella SPEC を `Refs` する commit / PR で進め、umbrella SPEC 本文の Tasks セクションをチェックボックスで更新する。新 SPEC を起こすのは umbrella の意図と明確に外れる別軸の作業に限定する。
 - Checkpoint: 1. 新規 SPEC 起票前に「既存の umbrella SPEC で受け止められないか」を 1 度自問する 2. 起票する場合は umbrella との関係（吸収 / 並列 / 独立）を本文の `Related` で明示する
+
+### 2026-05-12 (正式な gwt-spec を close しない)
+
+- Context: Phase 4 umbrella SPEC #191 の 5 サブタスク (A-E) がすべて develop に MERGED になった時点で「completed として close」してしまい、誤起票 #192 も同時に close した。user から「そもそも、正式な gwt-spec はクローズしません」と訂正を受けた。Phase 1-3 (#185 / #187 / #188) は実装 MERGED 後も OPEN 維持しているのが既存運用パターン (確認済み)。
+- Mistake: GitHub Issue の標準的な「実装が終わったら close」感覚で gwt-spec を扱った。gwt-spec が "living documentation" として運用されている前提を見落とし、Tasks セクションに「整理タスク: umbrella を close するかどうか user 判断」と書いた時点で誤誘導が始まっていた。
+- Rule: gwt-spec ラベル付き Issue は実装完了後も close せず OPEN 維持する。Phase 完了 / PR 全 MERGED / Tasks 全 `[x]` であっても `gh issue close` / `gwtd issue close` を呼ばない。Out of Scope の継続改善余地や後続 Phase の起点として残す。Tasks セクションに「整理タスク: umbrella を close する判断」のような close 誘導項目を作らない。重複 / 誤起票で close 候補となる場合でも、自律的に close せず必ず user 判断を仰ぐ。
+- Checkpoint: 1. SPEC 完走報告は最終 comment + Workspace 更新 + Tasks `[x]` で足りる 2. close 操作の代わりに「OPEN 維持運用方針」を Tasks / 運用方針セクションに明示する 3. 既存 SPEC の状態確認時に `[CLOSED]` を見かけたら「意図的な close か」を user に確認、意図せず close されていたら reopen 相談


### PR DESCRIPTION
## Summary

v0.11.0 リリースで `Build (aarch64-unknown-linux-gnu)` ジョブが `openssl-sys` の cross-compile に失敗し、依存していた `upload-release` ジョブが skip されて GitHub Release v0.11.0 にバイナリが上がらない状態でした。v0.11.1 はそのホットフィックスです。

`crates.io` の `unity-cli v0.11.0` は既に publish 済みのため、v0.11.0 は crates.io にのみ存在し、GitHub Release のバイナリは v0.11.1 から提供します。

## Changes

### 🐛 Bug Fixes
- *(release)* `aarch64-unknown-linux-gnu` cross-build に ARM64 OpenSSL (`libssl-dev:arm64`) と `pkg-config` 環境変数 (`PKG_CONFIG_ALLOW_CROSS`, `PKG_CONFIG_PATH`, `PKG_CONFIG_SYSROOT_DIR`) を追加。Ubuntu ports リポジトリを `dpkg --add-architecture arm64` で取り込み、native-tls 経由で `openssl-sys` を要求する `fastembed` / `hf-hub` の依存に対応。

## Version

`v0.11.1`

- `Cargo.toml`: 0.11.0 → 0.11.1
- `package.json`: 0.11.0 → 0.11.1
- `UnityCliBridge/Packages/unity-cli-bridge/package.json`: 0.11.0 → 0.11.1

## Closing Issues

None

## Related Issues / Links

- v0.11.0 で失敗した GitHub Actions run: https://github.com/akiojin/unity-cli/actions/runs/25685773156

🤖 Generated with [Claude Code](https://claude.com/claude-code)
