### PR TITLE
chore(release): v0.11.3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,7 +110,7 @@ jobs:
             artifact: unity-cli-linux-x64
             binary: unity-cli
           - target: aarch64-unknown-linux-gnu
-            os: ubuntu-latest
+            os: ubuntu-24.04-arm
             artifact: unity-cli-linux-arm64
             binary: unity-cli
           - target: aarch64-apple-darwin
@@ -131,12 +131,6 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
-      - name: Install cross-compilation tools (Linux ARM64)
-        if: matrix.target == 'aarch64-unknown-linux-gnu'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y gcc-aarch64-linux-gnu
-
       - name: Cache cargo registry and build
         uses: actions/cache@v5
         with:
@@ -149,8 +143,6 @@ jobs:
 
       - name: Build release binary
         run: cargo build --release --target ${{ matrix.target }}
-        env:
-          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: ${{ matrix.target == 'aarch64-unknown-linux-gnu' && 'aarch64-linux-gnu-gcc' || '' }}
 
       - name: Rename artifact (Unix)
         if: runner.os != 'Windows'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [0.11.3] - 2026-05-12
+
+### 🐛 Bug Fixes
+
+- *(release)* aarch64-unknown-linux-gnu ジョブを GitHub Actions の native ARM64 runner (`ubuntu-24.04-arm`) に切替。cross-compile 関連ステップ (gcc-aarch64-linux-gnu の apt インストール、`CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER` env) を削除し、`ort` (ONNX Runtime) が要求していた `libstdc++:arm64` の cross-link 問題を解消
+
 ## [0.11.2] - 2026-05-12
 
 ### 🐛 Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2977,7 +2977,7 @@ checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
 name = "unity-cli"
-version = "0.11.2"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unity-cli"
-version = "0.11.2"
+version = "0.11.3"
 edition = "2021"
 description = "Rust CLI for Unity Editor automation over the Unity TCP protocol"
 readme = "README.md"

--- a/UnityCliBridge/Packages/unity-cli-bridge/package.json
+++ b/UnityCliBridge/Packages/unity-cli-bridge/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.akiojin.unity-cli-bridge",
   "displayName": "Unity CLI Bridge",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "unity": "6000.0",
   "description": "Unity Editor bridge package for unity-cli automation (screenshots, video capture, scene analysis, input automation).",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unity-cli-workspace",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "private": true,
   "packageManager": "pnpm@10.33.0",
   "description": "Development environment for unity-cli",


### PR DESCRIPTION
## Summary

v0.11.2 では fastembed の rustls 化で `openssl-sys` 依存は除去できたものの、`fastembed -> ort` (ONNX Runtime) が依然として ARM64 `libstdc++` を要求し、`aarch64-linux-gnu-gcc` での cross-link で `cannot find -lstdc++` エラーとなりました。

v0.11.3 では aarch64-unknown-linux-gnu ジョブを GitHub Actions の **native ARM64 runner** (`ubuntu-24.04-arm`) に切替えてネイティブビルドにすることで、cross-compile 関連のトラブルを完全に回避します。

## Changes

### 🐛 Bug Fixes
- *(release)* `.github/workflows/release.yml` の build matrix で `aarch64-unknown-linux-gnu` の `os` を `ubuntu-latest` → `ubuntu-24.04-arm` に変更。GitHub の native ARM64 runner (public repo は無料) を使うことでクロスコンパイル不要になり、`gcc-aarch64-linux-gnu` の apt インストールと `CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER` env を削除。

## Version

`v0.11.3`

- `Cargo.toml`: 0.11.2 → 0.11.3
- `package.json`: 0.11.2 → 0.11.3
- `UnityCliBridge/Packages/unity-cli-bridge/package.json`: 0.11.2 → 0.11.3
- `.github/workflows/release.yml`: aarch64-linux ジョブを native ARM64 runner に切替

## Closing Issues

None

## Related Issues / Links

- v0.11.0 失敗ラン (openssl-sys): https://github.com/akiojin/unity-cli/actions/runs/25685773156
- v0.11.1 失敗ラン (apt deb822 sources): https://github.com/akiojin/unity-cli/actions/runs/25686883964
- v0.11.2 失敗ラン (libstdc++ cross-link): https://github.com/akiojin/unity-cli/actions/runs/25687668725

🤖 Generated with [Claude Code](https://claude.com/claude-code)
