### PR TITLE
docs(skills): unity-asset-management の get_asset_info action を明記 (#206)

### DIFF
--- a/.claude-plugin/plugins/unity-cli/skills/unity-asset-management/SKILL.md
+++ b/.claude-plugin/plugins/unity-cli/skills/unity-asset-management/SKILL.md
@@ -4,7 +4,7 @@ description: Manage Unity assets and import metadata with unity-cli. Use when th
 allowed-tools: Bash(unity-cli:*), Read, Grep, Glob
 metadata:
   author: akiojin
-  version: 0.3.0
+  version: 0.3.1
   category: assets
   triggers:
     - asset
@@ -39,12 +39,13 @@ Manage the Unity Asset Database, materials, animation clips, sprite atlases, imp
 
 ## Preferred Flow
 
-1. Inspect the target asset or material with `manage_asset_database` before changing it.
+1. Inspect the target asset with `manage_asset_database` using `{"action":"get_asset_info","assetPath":"..."}` before changing it.
 2. Run `analyze_asset_dependencies` before deleting, moving, or changing shared assets.
 3. Apply import or material changes with the narrowest possible payload.
 4. Call `refresh_assets` after any out-of-editor file change.
 
 ```bash
+unity-cli raw manage_asset_database --json '{"action":"get_asset_info","assetPath":"Assets/Textures/hero.png"}'
 unity-cli raw manage_asset_database --json '{"action":"refresh"}'
 unity-cli raw create_material --json '{"materialPath":"Assets/Materials/HeroMat.mat","shader":"Standard"}'
 unity-cli raw create_animation_clip --json '{"clipPath":"Assets/Animations/Hero.anim","spritePaths":["Assets/Sprites/Hero/idle_0.png"],"frameRate":12,"loopTime":true}'


### PR DESCRIPTION
## 概要

`unity-asset-management` skill の Preferred Flow が `manage_asset_database` の有効な action を示しておらず、例も `{"action":"refresh"}` のみだったため、agent/user が未サポートの `inspect` action を推測しやすかった問題を修正する。

Closes #206

## 変更内容

- Preferred Flow の手順1の文言を更新し、`{"action":"get_asset_info","assetPath":"..."}` を明記
- コード例に `get_asset_info` の呼び出しを追加
- `metadata.version` 0.3.0 → 0.3.1（doc/behavior 更新のため patch bump）

## 検証

- 有効な action を一次情報で確認:
  - `src/tooling/tool_catalog.rs`: enum に `get_asset_info`（`assetPath` 必須）
  - `UnityCliBridge/.../AssetDatabaseHandler.cs`: `case "get_asset_info"`
- `cargo run -- skills lint --severity error` → `15 skills checked, 0 violations`
- 変更は canonical SKILL.md のみ。`.claude/skills/` と `.agents/skills/` は canonical への symlink のため自動反映。

docs-only の skill markdown 変更のため、Rust/C# のビルド・テスト影響範囲外。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Unity Asset Management スキルドキュメントをアップデートしました。

* **Chores**
  * テスト実行の安定性向上のため、テストスレッド管理を最適化しました。
  * 開発環境の品質チェック手順を強化し、CI/ローカル環境での一貫性を確保しました。
  * 開発ワークフロー設定を追加し、プッシュ前の自動チェック機能を改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->